### PR TITLE
Added 'innerRadius' property to pie chart.

### DIFF
--- a/app/templates/ember_charts/documentation.hbs
+++ b/app/templates/ember_charts/documentation.hbs
@@ -271,6 +271,13 @@
       </td>
     </tr>
     <tr>
+      <td>innerRadius</td>
+      <td>0</td>
+      <td>
+        <p>The size of the inner radius, proportional to the radius.</p>
+      </td>
+    </tr>
+    <tr>
       <td>minSlicePercent</td>
       <td>5</td>
       <td>

--- a/dist/ember-charts.js
+++ b/dist/ember-charts.js
@@ -1243,6 +1243,7 @@ Ember.Charts.PieComponent = Ember.Charts.ChartComponent.extend(Ember.Charts.PieL
     return 0.25 * this.get('outerWidth');
   }).property('outerWidth'),
   maxRadius: 2000,
+  innerRadius: 0,
   sortFunction: Ember.computed(function() {
     switch (this.get('selectedSortType')) {
       case 'value':
@@ -1376,6 +1377,9 @@ Ember.Charts.PieComponent = Ember.Charts.ChartComponent.extend(Ember.Charts.PieL
   labelRadius: Ember.computed(function() {
     return this.get('radius') + this.get('labelPadding');
   }).property('radius', 'labelPadding'),
+  proportialInnerRadius: Ember.computed(function() {
+    return this.get('innerRadius') * this.get('radius');
+  }).property('innerRadius', 'radius'),
   getSliceColor: Ember.computed(function() {
     var _this = this;
     return function(d, i) {
@@ -1432,7 +1436,7 @@ Ember.Charts.PieComponent = Ember.Charts.ChartComponent.extend(Ember.Charts.PieL
   }).property('marginLeft', 'marginTop', 'width', 'height'),
   arc: Ember.computed(function() {
     var arc;
-    return arc = d3.svg.arc().outerRadius(this.get('radius')).innerRadius(0);
+    return arc = d3.svg.arc().outerRadius(this.get('radius')).innerRadius(this.get('proportialInnerRadius'));
   }).property('radius'),
   pie: Ember.computed(function() {
     return d3.layout.pie().startAngle(this.get('startOffset')).endAngle(this.get('startOffset') + Math.PI * 2).sort(null).value(function(d) {

--- a/src/charts/pie.coffee
+++ b/src/charts/pie.coffee
@@ -27,6 +27,9 @@ Ember.Charts.PieComponent = Ember.Charts.ChartComponent.extend(
   # Essentially we don't want a maximum radius
   maxRadius: 2000
 
+  # Inner radius proportional to the radius
+  innerRadius: 0
+
   # ----------------------------------------------------------------------------
   # Data
   # ----------------------------------------------------------------------------
@@ -171,6 +174,11 @@ Ember.Charts.PieComponent = Ember.Charts.ChartComponent.extend(
     @get('radius') + @get('labelPadding')
   .property 'radius', 'labelPadding'
 
+  # Inner radius relative to radius to create a donut graphic
+  proportialInnerRadius: Ember.computed ->
+    @get('innerRadius') * @get('radius')
+  .property 'innerRadius', 'radius'
+
   # ----------------------------------------------------------------------------
   # Color Configuration
   # ----------------------------------------------------------------------------
@@ -247,7 +255,7 @@ Ember.Charts.PieComponent = Ember.Charts.ChartComponent.extend(
   arc: Ember.computed ->
     arc = d3.svg.arc()
       .outerRadius(@get 'radius')
-      .innerRadius(0)
+      .innerRadius(@get 'proportialInnerRadius')
   .property 'radius'
 
   # Pie layout function starting with the largest slice at zero degrees or


### PR DESCRIPTION
Hey there,

I added a inner radius property to the pie chart which allows you to create donut charts. The `innerRadius` is proportional to the `radius`, so a `radius` of 100 and an `innerRadius` of 0.5 will result in a innerRadius of 50px.
