### PR TITLE
Add a JQuery event after the chart updates.

### DIFF
--- a/src/charts/chart.coffee
+++ b/src/charts/chart.coffee
@@ -133,5 +133,6 @@ Ember.Charts.ChartComponent = Ember.Component.extend(
       @clearChart()
     else
       @drawChart()
+      @$().trigger('embercharts.updated')
 
 )


### PR DESCRIPTION
I found the need to know when the chart has been fully rendered in order to grab some information from it.  Because you are currently doing this in an Ember.run.once, it happens in a separate run loop, and therefore I couldn't get it in an `afterRender` block.

Using a JQuery event, we can do something like this in the parent view:

```
this.$().one 'embercharts.updated', (event) =>
      @_logFinishedData()
```
