### PR TITLE
Update deprecated state for _state

### DIFF
--- a/src/charts/chart.coffee
+++ b/src/charts/chart.coffee
@@ -129,7 +129,7 @@ Ember.Charts.ChartComponent = Ember.Component.extend(
 
   # Remove previous drawing
   draw: ->
-    return unless @get('_state') is 'inDOM'
+    return unless @get('_state') or= @get('state') is 'inDOM'
     if @get('hasNoData')
       @clearChart()
     else


### PR DESCRIPTION
Update deprecated `state`for `_state`. In latest master `get('state')` is deprecated for `get('_state')`.
