### PR TITLE
Fix example app compilation dependencies

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -61,6 +61,8 @@ module.exports = (grunt) ->
           {src: ['app/index.html'], dest: 'gh_pages/index.html'},
           {expand: true, flatten: true, cwd: 'dependencies/', src: ['**/*.js'], dest: 'gh_pages/lib'},
           {expand: true, flatten: true, cwd: 'dependencies/', src: ['**/*.css'], dest: 'gh_pages/css'},
+          {expand: true, flatten: true, cwd: 'vendor/', src: ['**/*.js'], dest: 'gh_pages/lib'},
+          {expand: true, flatten: true, cwd: 'vendor/', src: ['**/*.css'], dest: 'gh_pages/css'},
           {expand: true, cwd: 'dependencies/font-awesome/font/', src: ['**'], dest: 'gh_pages/font'},
           {expand: true, cwd: 'app/assets/font/', src: ['**'], dest: 'gh_pages/font'},
           {expand: true, cwd: 'app/assets/img/', src: ['**'],  dest: 'gh_pages/img'}

--- a/app/app.coffee
+++ b/app/app.coffee
@@ -1,5 +1,5 @@
 # Dependencies
-require 'vendor/bootstrap/js/bootstrap'
+require 'vendor/bootstrap/dist/js/bootstrap'
 require 'dist/ember-charts'
 
 window.App = Ember.Application.create

--- a/app/index.html
+++ b/app/index.html
@@ -15,11 +15,11 @@
 <body>
 
   <!-- javascript -->
-  <script src="/gh_pages/lib/jquery-1.9.1.js"></script>
+  <script src="/gh_pages/lib/jquery.js"></script>
   <script src="/gh_pages/lib/jquery-ui-1.10.1.custom.min.js"></script>
   <script src="/gh_pages/lib/handlebars.js"></script>
   <script src="/gh_pages/lib/ember.js"></script>
-  <script src="/gh_pages/lib/d3.v3.js"></script>
+  <script src="/gh_pages/lib/d3.js"></script>
   <script src="/gh_pages/lib/lodash.js"></script>
   <script src="/gh_pages/app.js"></script>
 </body>


### PR DESCRIPTION
@bigsley @azirbel 

---

Correct directory example app searches for boostrap js in to be correct from
recent bower upgrade. Correct filenames for jquery and d3 which previously had
version tags in their filename. Add vendor folder to copy task for gh_pages
compile in grunt.

Author: Dylan Nugent
