### PR TITLE
Make the group optional when building a tooltip

### DIFF
--- a/dist/ember-charts.js
+++ b/dist/ember-charts.js
@@ -2049,7 +2049,11 @@ Ember.Charts.VerticalBarComponent = Ember.Charts.ChartComponent.extend(Ember.Cha
       isGroup = Ember.isArray(data.values);
       element = isGroup ? element.parentNode.parentNode : element;
       d3.select(element).classed('hovered', true);
-      content = "<span class=\"tip-label\">" + data.group + "</span>";
+      if (data.group) {
+        content = "<span class=\"tip-label\">" + data.group + "</span>";
+      } else {
+        content = '';
+      }
       formatLabel = _this.get('formatLabel');
       addValueLine = function(d) {
         content += "<span class=\"name\">" + d.label + ": </span>";

--- a/src/charts/vertical_bar.coffee
+++ b/src/charts/vertical_bar.coffee
@@ -301,7 +301,10 @@ Ember.Charts.VerticalBarComponent = Ember.Charts.ChartComponent.extend(
       d3.select(element).classed('hovered', yes)
 
       # Show tooltip
-      content = "<span class=\"tip-label\">#{data.group}</span>"
+      if data.group
+        content = "<span class=\"tip-label\">#{data.group}</span>"
+      else
+        content = ''
 
       formatLabel = @get 'formatLabel'
       addValueLine = (d) ->


### PR DESCRIPTION
Currently, if a group is not set for a vertical bar chart's bar the
tooltip will display "undefined". This will ensure that if no group is
given the group will just be left out when building the tooltip.

Before:

![screen shot 2014-08-21 at 11 02 42 am](https://cloud.githubusercontent.com/assets/105694/3998015/82969fda-2944-11e4-9897-0f8125b04d39.png)

After:

![screen shot 2014-08-21 at 11 03 35 am](https://cloud.githubusercontent.com/assets/105694/3998017/86bdb1d4-2944-11e4-90c6-5c1ab5ab6e12.png)
