### PR TITLE
Tweak offsets for X & Y axis titles

### DIFF
--- a/addon/mixins/axis-titles.js
+++ b/addon/mixins/axis-titles.js
@@ -55,14 +55,16 @@ const AxisTitlesMixin = Ember.Mixin.create({
    * axis title.
    * @type {Number}
    */
-  xTitleHorizontalOffset: 0,
+  xTitleHorizontalOffset: Ember.computed('width', 'graphicWidth', function(){
+    return -(this.get('width') - this.get('graphicWidth')) / 2;
+  }),
 
   /**
    * A variable to allow user to config the amount of veritcal offset for x
    * axis title.
    * @type {Number}
    */
-  xTitleVerticalOffset: 0,
+  xTitleVerticalOffset: 10,
 
   /**
    * A variable to allow user to config the amount of offset for y axis title.

--- a/tests/dummy/app/templates/scatter.hbs
+++ b/tests/dummy/app/templates/scatter.hbs
@@ -17,7 +17,6 @@
         hasYAxisTitle=hasYAxisTitle
         xTitleHorizontalOffset=xTitleHorizontalOffset
         yTitleVerticalOffset=yTitleVerticalOffset
-        xTitleVerticalOffset=10
       }}
     </div>
   </div>

--- a/tests/dummy/app/templates/time-series.hbs
+++ b/tests/dummy/app/templates/time-series.hbs
@@ -22,7 +22,6 @@
         yValueDisplayName=yValueDisplayName
         xTitleHorizontalOffset=xTitleHorizontalOffset
         yTitleVerticalOffset=yTitleVerticalOffset
-        xTitleVerticalOffset=10
       }}
     </div>
   </div>

--- a/tests/dummy/app/templates/vertical-bar.hbs
+++ b/tests/dummy/app/templates/vertical-bar.hbs
@@ -19,7 +19,6 @@
         yValueDisplayName=yValueDisplayName
         xTitleHorizontalOffset=xTitleHorizontalOffset
         yTitleVerticalOffset=yTitleVerticalOffset
-        xTitleVerticalOffset=10
       }}
     </div>
   </div>


### PR DESCRIPTION
Tweak `xTitleHorizontalOffset` and `xTitleVerticalOffset` to some default values so that the app that uses this lib does not have to tweak them.

@philpee2 @jordansmith42 @embooglement @thangdinh @cyril-sf 