### PR TITLE
Removes the default vertical margin

### DIFF
--- a/addon/components/chart-component.js
+++ b/addon/components/chart-component.js
@@ -11,9 +11,19 @@ export default Ember.Component.extend(ColorableMixin, ResizeHandlerMixin, {
   // Layout
   // ----------------------------------------------------------------------------
 
-  // Margin between viewport and svg boundary
-  horizontalMargin: 30,
-  verticalMargin: 30,
+  /**
+   * Default horizontal margin, for more granular control of left/right margins
+   * use `horizontalMarginLeft`/`horizontalMarginRight`
+   * @type {Number}
+   */
+  horizontalMargin: 0,
+
+  /**
+   * Allows for enough space for the top label on the y axis to protude half the
+   * line height above the top of the chart.
+   * @type {Number}
+   */
+  verticalMargin: 5,
 
   /**
    * Optional property to set specific left margin

--- a/addon/components/chart-component.js
+++ b/addon/components/chart-component.js
@@ -16,7 +16,7 @@ export default Ember.Component.extend(ColorableMixin, ResizeHandlerMixin, {
    * use `horizontalMarginLeft`/`horizontalMarginRight`
    * @type {Number}
    */
-  horizontalMargin: 0,
+  horizontalMargin: 30,
 
   /**
    * Allows for enough space for the top label on the y axis to protude half the

--- a/addon/components/scatter-chart.js
+++ b/addon/components/scatter-chart.js
@@ -22,6 +22,12 @@ export default ChartComponent.extend(LegendMixin, FloatingTooltipMixin,
   formatXValue: d3.format(',.2f'),
   formatYValue: d3.format(',.2f'),
 
+  /**
+   * Removes unnecessary padding around the chart
+   * @type {Number}
+   */
+  verticalMargin: 0,
+
   // Size of each icon on the scatter plot
   dotRadius: 7,
 


### PR DESCRIPTION
Perviously there was a default 30px vertical margin around time-series, scatter-chart and vertical-bar chart components. 

This appears to be largely arbitrary and can cause issues when trying to fit a chart into a layout. 

