### PR TITLE
Fix label width for horizontal bars with negative and postive values

### DIFF
--- a/addon/components/chart-component.js
+++ b/addon/components/chart-component.js
@@ -52,6 +52,22 @@ export default Ember.Component.extend(ColorableMixin, ResizeHandlerMixin, {
   }),
 
   /**
+   * An array of the values which are at least 0
+   * @type {Array<Number>}
+   */
+  positiveValues: Ember.computed('allFinishedDataValues.[]', function() {
+    return this.get('allFinishedDataValues').filter((val) => val >= 0);
+  }),
+
+  /**
+   * An array of the values which are less than 0
+   * @type {Array<Number>}
+   */
+  negativeValues: Ember.computed('allFinishedDataValues.[]', function() {
+    return this.get('allFinishedDataValues').filter((val) => val < 0);
+  }),
+
+  /**
    * Whether or not the data contains negative values.
    * @type {Boolean}
    */

--- a/addon/components/horizontal-bar-chart.js
+++ b/addon/components/horizontal-bar-chart.js
@@ -400,16 +400,31 @@ export default ChartComponent.extend(FloatingTooltipMixin,
         left: maxValueLabelWidth,
         right: maxGroupLabelWidth
       };
-    // If the values are a mix of positive and negative values, the left
-    // label width is the size of the value label representing the smallest
-    // value, and the right label width is the size of the value label
-    // representing the largest value
+    // If the values are a mix of positive and negative values, there is a mix
+    // value and grouping labels on each side. Find the largest one on either
+    // side.
     } else {
-      const minValue = this.get('minValue');
-      const maxValue = this.get('maxValue');
-      const [leftWidth, rightWidth] = [minValue, maxValue].map((val) => {
-        const label = this._getElementForValue(valueLabelElements, val);
-        return label.getComputedTextLength();
+      const positiveValues = this.get('positiveValues');
+      const negativeValues = this.get('negativeValues');
+
+      const positiveGroupingLabels = positiveValues.map((val) => {
+        return this._getElementForValue(groupLabelElements, val);
+      });
+      const positiveValueLabels = positiveValues.map((val) => {
+        return this._getElementForValue(valueLabelElements, val);
+      });
+      const negativeGroupingLabels = negativeValues.map((val) => {
+        return this._getElementForValue(groupLabelElements, val);
+      });
+      const negativeValueLabels = negativeValues.map((val) => {
+        return this._getElementForValue(valueLabelElements, val);
+      });
+
+      const leftLabels = negativeValueLabels.concat(positiveGroupingLabels);
+      const rightLabels = positiveValueLabels.concat(negativeGroupingLabels);
+
+      const [leftWidth, rightWidth] = [leftLabels, rightLabels].map((elements) => {
+        return this._maxWidthOfElements(elements);
       });
       return {
         left: leftWidth,


### PR DESCRIPTION
For horizontal bar charts with very lopsided values (e.g a positive value with
very large magnitude and a negative value with very small magnitude), the
labels were being cut off because the chart was only using value labels to
compute margins, instead of also taking into account grouping labels on the
left side of the chart

![image](https://cloud.githubusercontent.com/assets/2244653/11483992/7f981ee0-9760-11e5-8628-68095823b327.png)

@Addepar/fire 