### PR TITLE
Fixing horizontal charts to flush in case of both negative and positive values

### DIFF
--- a/addon/components/horizontal-bar-chart.js
+++ b/addon/components/horizontal-bar-chart.js
@@ -462,7 +462,7 @@ const HorizontalBarChartComponent = ChartComponent.extend(FloatingTooltipMixin,
       var maxValue = this.get('maxValue');
       var valueRange = maxValue + minValue;
       var containerWidth = this.get('outerWidth');
-      var chartWidth = containerWidth - maxNegativeValueLabelWidth - maxPositiveValueLabelWidth - 2*padding;
+      var chartWidth = containerWidth - maxNegativeValueLabelWidth - maxPositiveValueLabelWidth - 2 * padding;
 
       var leftGroupLabelWidth = maxPositiveGroupingLabelWidth;
       var leftChartWidth = maxNegativeValueLabelWidth + minValue/valueRange * chartWidth;
@@ -475,9 +475,9 @@ const HorizontalBarChartComponent = ChartComponent.extend(FloatingTooltipMixin,
       var rightWidth = maxPositiveValueLabelWidth;
 
       if (leftGroupLabelWidth > leftChartWidth) {
-        leftWidth = leftGroupLabelWidth - minValue * (containerWidth - leftGroupLabelWidth - rightWidth) / maxValue;
+        leftWidth = leftGroupLabelWidth - minValue * (containerWidth - leftGroupLabelWidth - rightWidth - 2 * padding) / maxValue;
       } else if (rightGroupLabelWidth > rightChartWidth) {
-        rightWidth = rightGroupLabelWidth - maxValue * (containerWidth - rightGroupLabelWidth - leftWidth) / minValue;
+        rightWidth = rightGroupLabelWidth - maxValue * (containerWidth - rightGroupLabelWidth - leftWidth - 2 * padding) / minValue;
       }
 
       /*const leftLabels = negativeValueLabels.concat(positiveGroupingLabels);

--- a/addon/components/horizontal-bar-chart.js
+++ b/addon/components/horizontal-bar-chart.js
@@ -452,10 +452,10 @@ const HorizontalBarChartComponent = ChartComponent.extend(FloatingTooltipMixin,
       });
 
       var maxNegativeValueLabelWidth = this._maxWidthOfElements(negativeValueLabels);
-      var maxPositiveGroupingLabelWidth = this._maxWidthOfElements(positiveGroupingLabels);
+      var maxPositiveGroupingLabelWidth = maxLabelWidth || this._maxWidthOfElements(positiveGroupingLabels);
 
       var maxPositiveValueLabelWidth = this._maxWidthOfElements(positiveValueLabels);
-      var maxNegativeGroupingLabelWidth = this._maxWidthOfElements(negativeGroupingLabels);
+      var maxNegativeGroupingLabelWidth = maxLabelWidth || this._maxWidthOfElements(negativeGroupingLabels);
 
       var padding = this.get('labelPadding');
       var minValue = Math.abs(this.get('minValue'));
@@ -550,7 +550,7 @@ const HorizontalBarChartComponent = ChartComponent.extend(FloatingTooltipMixin,
       horizontalMarginRight: labelWidths.right + labelPadding
     });
 
-    var labelWidth;
+    /*var labelWidth;
     if (this.get('hasAllPositiveValues')) {
       labelWidth = labelWidths.left;
     } else if (this.get('hasAllNegativeValues')) {
@@ -559,14 +559,15 @@ const HorizontalBarChartComponent = ChartComponent.extend(FloatingTooltipMixin,
       // If the chart contains a mix of negative and positive values, there are
       // grouping labels on both sides of the chart
       labelWidth = d3.max([labelWidths.left, labelWidths.right]);
-    }
+    }*/
+    var labelWidth = this.get('maxLabelWidth') || this.get('outerWidth');
     const labelTrimmer = LabelTrimmer.create({
       getLabelSize: () => labelWidth,
       getLabelText: (d) => d.label
     });
 
-    /*groups.select('text.group')
-      .call(labelTrimmer.get('trim'));*/
+    groups.select('text.group')
+      .call(labelTrimmer.get('trim'));
   }
 });
 

--- a/addon/components/horizontal-bar-chart.js
+++ b/addon/components/horizontal-bar-chart.js
@@ -461,24 +461,24 @@ const HorizontalBarChartComponent = ChartComponent.extend(FloatingTooltipMixin,
       var minValue = Math.abs(this.get('minValue'));
       var maxValue = this.get('maxValue');
       var valueRange = maxValue + minValue;
-      var containerWidth = this.get('width');
+      var containerWidth = this.get('outerWidth');
       var chartWidth = containerWidth - maxNegativeValueLabelWidth - maxPositiveValueLabelWidth - 2*padding;
 
-      var leftGroupLabelWidth = maxPositiveGroupingLabelWidth + padding;
-      var leftChartWidth = maxNegativeValueLabelWidth + padding + minValue/valueRange * chartWidth;
+      var leftGroupLabelWidth = maxPositiveGroupingLabelWidth;
+      var leftChartWidth = maxNegativeValueLabelWidth + minValue/valueRange * chartWidth;
 
 
-      var rightGroupLabelWidth = maxNegativeGroupingLabelWidth + padding;
-      var rightChartWidth = maxPositiveValueLabelWidth + padding + maxValue/valueRange * chartWidth;
+      var rightGroupLabelWidth = maxNegativeGroupingLabelWidth;
+      var rightChartWidth = maxPositiveValueLabelWidth + maxValue/valueRange * chartWidth;
 
       var leftWidth = maxNegativeValueLabelWidth;
       if (leftGroupLabelWidth > leftChartWidth) {
-        leftWidth += leftGroupLabelWidth - leftChartWidth - padding;
+        leftWidth += leftGroupLabelWidth - leftChartWidth;
       }
 
       var rightWidth = maxPositiveValueLabelWidth;
       if (rightGroupLabelWidth > rightChartWidth) {
-        rightWidth += rightGroupLabelWidth - rightChartWidth - padding;
+        rightWidth += rightGroupLabelWidth - rightChartWidth;
       }
 
       /*const leftLabels = negativeValueLabels.concat(positiveGroupingLabels);
@@ -539,7 +539,7 @@ const HorizontalBarChartComponent = ChartComponent.extend(FloatingTooltipMixin,
     const labelWidths = this._computeLabelWidths(groupLabelElements, valueLabelElements);
     // labelWidth is used for computations around the left margin, so set it
     // to the width of the left label
-    this.set('labelWidth', labelWidths.left);
+    //this.set('labelWidth', labelWidths.left);
 
     // Add a few extra pixels of padding to ensure that labels don't clip off
     // the edge of the chart

--- a/addon/components/horizontal-bar-chart.js
+++ b/addon/components/horizontal-bar-chart.js
@@ -451,12 +451,42 @@ const HorizontalBarChartComponent = ChartComponent.extend(FloatingTooltipMixin,
         return this._getElementForValue(valueLabelElements, val);
       });
 
-      const leftLabels = negativeValueLabels.concat(positiveGroupingLabels);
+      var maxNegativeValueLabelWidth = this._maxWidthOfElements(negativeValueLabels);
+      var maxPositiveGroupingLabelWidth = this._maxWidthOfElements(positiveGroupingLabels);
+
+      var maxPositiveValueLabelWidth = this._maxWidthOfElements(positiveValueLabels);
+      var maxNegativeGroupingLabelWidth = this._maxWidthOfElements(negativeGroupingLabels);
+
+      var padding = this.get('labelPadding');
+      var minValue = Math.abs(this.get('minValue'));
+      var maxValue = this.get('maxValue');
+      var valueRange = maxValue + minValue;
+      var containerWidth = this.get('width');
+      var chartWidth = containerWidth - maxNegativeValueLabelWidth - maxPositiveValueLabelWidth;
+
+      var leftGroupLabelWidthRatio = (maxPositiveGroupingLabelWidth+padding)/containerWidth;
+      var leftChartWidthRatio = (maxNegativeValueLabelWidth+padding)/containerWidth + minValue/valueRange * chartWidth/containerWidth;
+
+
+      var rightGroupLabelWidthRatio = (maxNegativeGroupingLabelWidth + padding)/containerWidth;
+      var rightChartWidthRatio = (maxPositiveValueLabelWidth+padding)/containerWidth + maxValue/valueRange * chartWidth/containerWidth;
+
+      var leftWidth = maxNegativeValueLabelWidth;
+      if (leftGroupLabelWidthRatio > leftChartWidthRatio) {
+        leftWidth += (leftGroupLabelWidthRatio-leftChartWidthRatio)*containerWidth;
+      }
+
+      var rightWidth = maxPositiveValueLabelWidth;
+      if (rightGroupLabelWidthRatio > rightChartWidthRatio) {
+        rightWidth += (rightGroupLabelWidthRatio-rightChartWidthRatio)*containerWidth;
+      }
+
+      /*const leftLabels = negativeValueLabels.concat(positiveGroupingLabels);
       const rightLabels = positiveValueLabels.concat(negativeGroupingLabels);
 
       const [leftWidth, rightWidth] = [leftLabels, rightLabels].map((elements) => {
         return this._maxWidthOfElements(elements);
-      });
+      });*/
       return {
         left: leftWidth,
         right: rightWidth
@@ -536,8 +566,8 @@ const HorizontalBarChartComponent = ChartComponent.extend(FloatingTooltipMixin,
       getLabelText: (d) => d.label
     });
 
-    groups.select('text.group')
-      .call(labelTrimmer.get('trim'));
+    /*groups.select('text.group')
+      .call(labelTrimmer.get('trim'));*/
   }
 });
 

--- a/addon/components/horizontal-bar-chart.js
+++ b/addon/components/horizontal-bar-chart.js
@@ -462,23 +462,23 @@ const HorizontalBarChartComponent = ChartComponent.extend(FloatingTooltipMixin,
       var maxValue = this.get('maxValue');
       var valueRange = maxValue + minValue;
       var containerWidth = this.get('width');
-      var chartWidth = containerWidth - maxNegativeValueLabelWidth - maxPositiveValueLabelWidth;
+      var chartWidth = containerWidth - maxNegativeValueLabelWidth - maxPositiveValueLabelWidth - 2*padding;
 
-      var leftGroupLabelWidthRatio = (maxPositiveGroupingLabelWidth+padding)/containerWidth;
-      var leftChartWidthRatio = (maxNegativeValueLabelWidth+padding)/containerWidth + minValue/valueRange * chartWidth/containerWidth;
+      var leftGroupLabelWidth = maxPositiveGroupingLabelWidth + padding;
+      var leftChartWidth = maxNegativeValueLabelWidth + padding + minValue/valueRange * chartWidth;
 
 
-      var rightGroupLabelWidthRatio = (maxNegativeGroupingLabelWidth + padding)/containerWidth;
-      var rightChartWidthRatio = (maxPositiveValueLabelWidth+padding)/containerWidth + maxValue/valueRange * chartWidth/containerWidth;
+      var rightGroupLabelWidth = maxNegativeGroupingLabelWidth + padding;
+      var rightChartWidth = maxPositiveValueLabelWidth + padding + maxValue/valueRange * chartWidth;
 
       var leftWidth = maxNegativeValueLabelWidth;
-      if (leftGroupLabelWidthRatio > leftChartWidthRatio) {
-        leftWidth += (leftGroupLabelWidthRatio-leftChartWidthRatio)*containerWidth;
+      if (leftGroupLabelWidth > leftChartWidth) {
+        leftWidth += leftGroupLabelWidth - leftChartWidth - padding;
       }
 
       var rightWidth = maxPositiveValueLabelWidth;
-      if (rightGroupLabelWidthRatio > rightChartWidthRatio) {
-        rightWidth += (rightGroupLabelWidthRatio-rightChartWidthRatio)*containerWidth;
+      if (rightGroupLabelWidth > rightChartWidth) {
+        rightWidth += rightGroupLabelWidth - rightChartWidth - padding;
       }
 
       /*const leftLabels = negativeValueLabels.concat(positiveGroupingLabels);

--- a/addon/components/horizontal-bar-chart.js
+++ b/addon/components/horizontal-bar-chart.js
@@ -462,8 +462,8 @@ const HorizontalBarChartComponent = ChartComponent.extend(FloatingTooltipMixin,
       var maxValue = this.get('maxValue');
       var valueRange = maxValue + minValue;
       var containerWidth = this.get('outerWidth');
-      var chartWidth = containerWidth - maxNegativeValueLabelWidth - maxPositiveValueLabelWidth - 2 * padding;
       const axisTitleOffset = this.get('yAxisTitleHeightOffset') + 5;
+      var chartWidth = containerWidth - maxNegativeValueLabelWidth - maxPositiveValueLabelWidth - 2 * padding - axisTitleOffset;
 
       var leftGroupLabelWidth = maxPositiveGroupingLabelWidth;
       var leftChartWidth = maxNegativeValueLabelWidth + minValue/valueRange * chartWidth;
@@ -474,11 +474,14 @@ const HorizontalBarChartComponent = ChartComponent.extend(FloatingTooltipMixin,
 
       var leftWidth = maxNegativeValueLabelWidth;
       var rightWidth = maxPositiveValueLabelWidth;
+      var chartPadding = 2 * padding + axisTitleOffset;
 
       if (leftGroupLabelWidth > leftChartWidth) {
-        leftWidth = leftGroupLabelWidth - minValue * (containerWidth - leftGroupLabelWidth - rightWidth - 2 * padding - axisTitleOffset) / maxValue;
+        leftWidth = leftGroupLabelWidth - minValue * (containerWidth - leftGroupLabelWidth - rightWidth - chartPadding) / maxValue;
+        leftWidth = Math.min(leftWidth, containerWidth - rightWidth - chartPadding);
       } else if (rightGroupLabelWidth > rightChartWidth) {
-        rightWidth = rightGroupLabelWidth - maxValue * (containerWidth - rightGroupLabelWidth - leftWidth - 2 * padding) / minValue;
+        rightWidth = rightGroupLabelWidth - maxValue * (containerWidth - rightGroupLabelWidth - leftWidth - chartPadding) / minValue;
+        rightWidth = Math.min(rightWidth, containerWidth - leftWidth - chartPadding);
       }
 
       /*const leftLabels = negativeValueLabels.concat(positiveGroupingLabels);

--- a/addon/components/horizontal-bar-chart.js
+++ b/addon/components/horizontal-bar-chart.js
@@ -452,10 +452,10 @@ const HorizontalBarChartComponent = ChartComponent.extend(FloatingTooltipMixin,
       });
 
       var maxNegativeValueLabelWidth = this._maxWidthOfElements(negativeValueLabels);
-      var maxPositiveGroupingLabelWidth = maxLabelWidth || this._maxWidthOfElements(positiveGroupingLabels);
+      var maxPositiveGroupingLabelWidth = Math.min(maxLabelWidth, this._maxWidthOfElements(positiveGroupingLabels));
 
       var maxPositiveValueLabelWidth = this._maxWidthOfElements(positiveValueLabels);
-      var maxNegativeGroupingLabelWidth = maxLabelWidth || this._maxWidthOfElements(negativeGroupingLabels);
+      var maxNegativeGroupingLabelWidth = Math.min(maxLabelWidth, this._maxWidthOfElements(negativeGroupingLabels));
 
       var padding = this.get('labelPadding');
       var minValue = Math.abs(this.get('minValue'));

--- a/addon/components/horizontal-bar-chart.js
+++ b/addon/components/horizontal-bar-chart.js
@@ -463,6 +463,7 @@ const HorizontalBarChartComponent = ChartComponent.extend(FloatingTooltipMixin,
       var valueRange = maxValue + minValue;
       var containerWidth = this.get('outerWidth');
       var chartWidth = containerWidth - maxNegativeValueLabelWidth - maxPositiveValueLabelWidth - 2 * padding;
+      const axisTitleOffset = this.get('yAxisTitleHeightOffset') + 5;
 
       var leftGroupLabelWidth = maxPositiveGroupingLabelWidth;
       var leftChartWidth = maxNegativeValueLabelWidth + minValue/valueRange * chartWidth;
@@ -475,7 +476,7 @@ const HorizontalBarChartComponent = ChartComponent.extend(FloatingTooltipMixin,
       var rightWidth = maxPositiveValueLabelWidth;
 
       if (leftGroupLabelWidth > leftChartWidth) {
-        leftWidth = leftGroupLabelWidth - minValue * (containerWidth - leftGroupLabelWidth - rightWidth - 2 * padding) / maxValue;
+        leftWidth = leftGroupLabelWidth - minValue * (containerWidth - leftGroupLabelWidth - rightWidth - 2 * padding - axisTitleOffset) / maxValue;
       } else if (rightGroupLabelWidth > rightChartWidth) {
         rightWidth = rightGroupLabelWidth - maxValue * (containerWidth - rightGroupLabelWidth - leftWidth - 2 * padding) / minValue;
       }
@@ -538,7 +539,7 @@ const HorizontalBarChartComponent = ChartComponent.extend(FloatingTooltipMixin,
     const labelWidths = this._computeLabelWidths(groupLabelElements, valueLabelElements);
     // labelWidth is used for computations around the left margin, so set it
     // to the width of the left label
-    //this.set('labelWidth', labelWidths.left);
+    this.set('labelWidth', labelWidths.left);
 
     // Add a few extra pixels of padding to ensure that labels don't clip off
     // the edge of the chart

--- a/addon/components/horizontal-bar-chart.js
+++ b/addon/components/horizontal-bar-chart.js
@@ -415,7 +415,7 @@ const HorizontalBarChartComponent = ChartComponent.extend(FloatingTooltipMixin,
     const maxValueLabelWidth = this._maxWidthOfElements(valueLabelElements);
     const maxGroupLabelWidth = this._maxWidthOfElements(groupLabelElements);
 
-    const maxLabelWidth = this.get('maxLabelWidth');
+    const maxLabelWidth = this.get('maxLabelWidth') || this.get('outerWidth');
 
     // If all values are positive, the grouping labels are on the left and the
     // value labels are on the right

--- a/addon/components/horizontal-bar-chart.js
+++ b/addon/components/horizontal-bar-chart.js
@@ -472,13 +472,12 @@ const HorizontalBarChartComponent = ChartComponent.extend(FloatingTooltipMixin,
       var rightChartWidth = maxPositiveValueLabelWidth + maxValue/valueRange * chartWidth;
 
       var leftWidth = maxNegativeValueLabelWidth;
-      if (leftGroupLabelWidth > leftChartWidth) {
-        leftWidth += leftGroupLabelWidth - leftChartWidth;
-      }
-
       var rightWidth = maxPositiveValueLabelWidth;
-      if (rightGroupLabelWidth > rightChartWidth) {
-        rightWidth += rightGroupLabelWidth - rightChartWidth;
+
+      if (leftGroupLabelWidth > leftChartWidth) {
+        leftWidth = leftGroupLabelWidth - minValue * (containerWidth - leftGroupLabelWidth - rightWidth) / maxValue;
+      } else if (rightGroupLabelWidth > rightChartWidth) {
+        rightWidth = rightGroupLabelWidth - maxValue * (containerWidth - rightGroupLabelWidth - leftWidth) / minValue;
       }
 
       /*const leftLabels = negativeValueLabels.concat(positiveGroupingLabels);

--- a/addon/components/horizontal-bar-chart.js
+++ b/addon/components/horizontal-bar-chart.js
@@ -462,8 +462,9 @@ const HorizontalBarChartComponent = ChartComponent.extend(FloatingTooltipMixin,
       var maxValue = this.get('maxValue');
       var valueRange = maxValue + minValue;
       var containerWidth = this.get('outerWidth');
-      const axisTitleOffset = this.get('yAxisTitleHeightOffset') + 5;
-      var chartWidth = containerWidth - maxNegativeValueLabelWidth - maxPositiveValueLabelWidth - 2 * padding - axisTitleOffset;
+      var axisTitleOffset = this.get('yAxisTitleHeightOffset') + 5;
+      var chartPadding = 2 * padding + axisTitleOffset;
+      var chartWidth = containerWidth - maxNegativeValueLabelWidth - maxPositiveValueLabelWidth - chartPadding;
 
       var leftGroupLabelWidth = maxPositiveGroupingLabelWidth;
       var leftChartWidth = maxNegativeValueLabelWidth + minValue/valueRange * chartWidth;
@@ -474,7 +475,6 @@ const HorizontalBarChartComponent = ChartComponent.extend(FloatingTooltipMixin,
 
       var leftWidth = maxNegativeValueLabelWidth;
       var rightWidth = maxPositiveValueLabelWidth;
-      var chartPadding = 2 * padding + axisTitleOffset;
 
       if (leftGroupLabelWidth > leftChartWidth) {
         leftWidth = leftGroupLabelWidth - minValue * (containerWidth - leftGroupLabelWidth - rightWidth - chartPadding) / maxValue;

--- a/tests/dummy/app/controllers/horizontal-bar.js
+++ b/tests/dummy/app/controllers/horizontal-bar.js
@@ -15,6 +15,9 @@ import zeroes from '../models/single_group/zeroes';
 import sum_to_zero from '../models/single_group/sum_to_zero';
 import bad_range from '../models/single_group/bad_range';
 import all_negatives from '../models/single_group/all_negatives';
+import long_grouping_labels from '../models/single_group/long_grouping_labels';
+import long_value_labels from '../models/single_group/long_value_labels';
+import long_grouping_and_value_labels from '../models/single_group/long_grouping_and_value_labels';
 
 export default SlideController.extend({
 
@@ -70,7 +73,10 @@ export default SlideController.extend({
       zeroes: zeroes,
       sum_to_zero: sum_to_zero,
       bad_range: bad_range,
-      all_negatives: all_negatives
+      all_negatives: all_negatives,
+      long_grouping_labels: long_grouping_labels,
+      long_value_labels: long_value_labels,
+      long_grouping_and_value_labels: long_grouping_and_value_labels
     };
   }),
 

--- a/tests/dummy/app/models/single_group/long_grouping_and_value_labels.js
+++ b/tests/dummy/app/models/single_group/long_grouping_and_value_labels.js
@@ -1,0 +1,26 @@
+export default [{
+    label: "Label 1 - There is a long grouping label on the left",
+    value: 1029380192830981012,
+    type: "percent"
+  }, {
+    label: "Label 2 - 10293801928309123",
+    value: 12312312312123123,
+    type: "percent"
+  }, {
+    label: "Label 3 - 192083091283123",
+    value: 10299380192830911,
+    type: "percent"
+  }, {
+    label: "Label 4 - There is a long grouping lable on the right that should be flush",
+    value: -510293809123123123,
+    type: "percent"
+  }, {
+    label: "Label 5",
+    value: 0,
+    type: "percent"
+  }, {
+    label: "Label 6",
+    value: -123010928301901928,
+    type: "percent"
+}];
+

--- a/tests/dummy/app/models/single_group/long_grouping_labels.js
+++ b/tests/dummy/app/models/single_group/long_grouping_labels.js
@@ -1,0 +1,26 @@
+export default [{
+    label: "Label 1 - There is a long grouping label on the left",
+    value: 0,
+    type: "percent"
+  }, {
+    label: "Label 2",
+    value: 2,
+    type: "percent"
+  }, {
+    label: "Label 3",
+    value: 3,
+    type: "percent"
+  }, {
+    label: "Label 4 - There is a long grouping lable on the right that should be flush",
+    value: -5,
+    type: "percent"
+  }, {
+    label: "Label 5",
+    value: 0,
+    type: "percent"
+  }, {
+    label: "Label 6",
+    value: 0,
+    type: "percent"
+}];
+

--- a/tests/dummy/app/models/single_group/long_value_labels.js
+++ b/tests/dummy/app/models/single_group/long_value_labels.js
@@ -1,0 +1,26 @@
+export default [{
+    label: "Label 1",
+    value: 1230981230,
+    type: "percent"
+  }, {
+    label: "Label 2",
+    value: 20912312,
+    type: "percent"
+  }, {
+    label: "Label 3",
+    value: 3212123,
+    type: "percent"
+  }, {
+    label: "Label 4",
+    value: -512019283,
+    type: "percent"
+  }, {
+    label: "Label 5",
+    value: 0,
+    type: "percent"
+  }, {
+    label: "Label 6",
+    value: -120938123,
+    type: "percent"
+}];
+

--- a/tests/dummy/app/models/single_group/sum_to_zero.js
+++ b/tests/dummy/app/models/single_group/sum_to_zero.js
@@ -1,5 +1,5 @@
 export default [{
-    label: "Label 1",
+    label: "A very long Label 1 that should add a lot of left padding",
     value: 0,
     type: "percent"
   }, {

--- a/tests/unit/horizontal-bar-test.js
+++ b/tests/unit/horizontal-bar-test.js
@@ -120,6 +120,7 @@ test("Value/Grouping Labels appear on the left/right when all data is 0 or negat
 });
 
 test("Labels aren't trimmed when width is small", function(assert) {
+   assert.expect(1);
   const testData = [{
     label: "some really long label that is really long",
     value: 10000,
@@ -143,7 +144,68 @@ test("Labels aren't trimmed when width is small", function(assert) {
   const noLabelsTruncated = _.all(groupLabels, function(label) {
     return label.textContent.indexOf('...') === -1;
   });
-  assert.ok(noLabelsTruncated,
-    `For charts with a mix of positive and negative values, labels are not
-      truncated when width is small`);
+  assert.ok(noLabelsTruncated, 'For charts with a mix of positive and negative values, labels are not' +
+      'truncated when width is small');
+});
+
+test("Labels are flush with edges of the chart", function(assert) {
+  assert.expect(3);
+
+  const testData = [{
+    label: "Label 1",
+    value: -5,
+    type: "percent"
+  }, {
+    label: "Label 2 - There is a long grouping lable on the right that should be flush",
+    value: -1,
+    type: "percent"
+  }, {
+    label: "Label 3",
+    value: 0,
+    type: "percent"
+  }, {
+    label: "Label 4",
+    value: 0,
+    type: "percent"
+  }, {
+    label: "Label 5",
+    value: 0,
+    type: "percent"
+  }, {
+    label: "Label 6 - There is a long grouping label on the right that is not flush",
+    value: 2,
+    type: "percent"
+  }];
+
+  const component = this.subject({
+    data: testData
+  });
+
+  this.render();
+
+  const longValueLabel = component.$("text.value:first");
+  const longGroupLabel = component.$("text.group:eq(1)");
+  const chartViewport = component.$('.chart-viewport');
+
+  debugger;
+
+  assert.equal(longValueLabel.position().left, chartViewport.position().left,
+    'Largest Left Value Label + Bar Width is longer than Left Group Labels, ' +
+        'therefore Left Value Label should be flush on the left');
+  assert.equal(longGroupLabel.position().right, chartViewport.position().right,
+    'Right Group label is longer than Largest Left Value Labels + Bar Widths,' +
+        'therefore Right Group Label should be flush on the right');
+
+
+  const groupLabels = component.$('text.group');
+  const valueLabels = component.$('text.value');
+  const noValueLabelsTruncated = _.all(valueLabels, function(label) {
+    return label.textContent.indexOf('...') === -1;
+  });
+
+  const noGroupLabelsTruncated = _.all(groupLabels, function(label) {
+    return label.textContent.indexOf('...') === -1;
+  });
+
+  assert.ok(noGroupLabelsTruncated && noValueLabelsTruncated, 'Labels are not truncated');
 });

--- a/tests/unit/horizontal-bar-test.js
+++ b/tests/unit/horizontal-bar-test.js
@@ -187,8 +187,6 @@ test("Labels are flush with edges of the chart", function(assert) {
   const longGroupLabel = component.$("text.group:eq(1)");
   const chartViewport = component.$('.chart-viewport');
 
-  debugger;
-
   assert.equal(longValueLabel.position().left, chartViewport.position().left,
     'Largest Left Value Label + Bar Width is longer than Left Group Labels, ' +
         'therefore Left Value Label should be flush on the left');


### PR DESCRIPTION
This happens only when the mix of both positive and negative values with long grouping labels. This PR should fix most of those scenarios.

@Addepar/fire @philpee2 