### PR TITLE
Fix #172: In Vertical Bar Charts, bar groups lacking some bars wrongly color and highlight their remaining bars

### DIFF
--- a/Brocfile.js
+++ b/Brocfile.js
@@ -15,5 +15,6 @@ var app = new EmberAddon();
 app.import(app.bowerDirectory + '/jquery-ui/themes/base/jquery-ui.css');
 app.import(app.bowerDirectory + '/d3/d3.js');
 app.import(app.bowerDirectory + '/lodash/lodash.js');
+app.import(app.bowerDirectory + '/tinycolor/tinycolor.js');
 
 module.exports = app.toTree();

--- a/addon/components/vertical-bar-chart.js
+++ b/addon/components/vertical-bar-chart.js
@@ -519,16 +519,20 @@ const VerticalBarChartComponent = ChartComponent.extend(LegendMixin,
     };
   }),
 
-  stackedBarAttrs: Ember.computed('yScale', 'groupWidth', 'labelIDMapping.[]', function() {
-    var yScale, zeroDisplacement;
-    zeroDisplacement = 1;
-    yScale = this.get('yScale');
+  commonBarAttrs: Ember.computed('labelIDMapping.[]', function() {
     return {
-      "class": (barSection) => {
-        var id;
-        id = this.get('labelIDMapping')[barSection.label];
+      class: (d) => {
+        var id = this.get('labelIDMapping')[d.label];
         return "grouping-" + id;
-      },
+      }
+    };
+  }),
+
+  stackedBarAttrs: Ember.computed('commonBarAttrs', 'yScale', 'groupWidth', function() {
+    var zeroDisplacement = 1;
+    var yScale = this.get('yScale');
+
+    return _.assign({
       'stroke-width': 0,
       width: () => this.get('groupWidth'),
       x: null,
@@ -538,15 +542,14 @@ const VerticalBarChartComponent = ChartComponent.extend(LegendMixin,
       height: function(barSection) {
         return yScale(barSection.y0) - yScale(barSection.y1);
       }
-    };
+    }, this.get('commonBarAttrs'));
   }),
 
-  groupedBarAttrs: Ember.computed('yScale', 'getSeriesColor', 'barWidth', 'xWithinGroupScale', function() {
+  groupedBarAttrs: Ember.computed('commonBarAttrs', 'yScale', 'barWidth', 'xWithinGroupScale', function() {
     var zeroDisplacement = 1;
     var yScale = this.get('yScale');
 
-    return {
-      class: (d, i) => "grouping-" + i,
+    return _.assign({
       'stroke-width': 0,
       width: () => this.get('barWidth'),
       x: (d) => this.get('xWithinGroupScale')(d.label),
@@ -560,7 +563,7 @@ const VerticalBarChartComponent = ChartComponent.extend(LegendMixin,
           return yScale(0) + zeroDisplacement;
         }
       }
-    };
+    }, this.get('commonBarAttrs'));
   }),
 
   labelAttrs: Ember.computed('barWidth', 'isGrouped', 'stackBars', 'groupWidth',

--- a/addon/components/vertical-bar-chart.js
+++ b/addon/components/vertical-bar-chart.js
@@ -408,15 +408,13 @@ const VerticalBarChartComponent = ChartComponent.extend(LegendMixin,
     return result;
   }),
 
-  fnGetBarColor: Ember.computed('barColors', 'getSeriesColor', function() {
+  fnGetBarColor: Ember.computed('barColors', function() {
     var barColors = this.get('barColors');
-    var fnGetSeriesColor = this.get('getSeriesColor');
-
-    return function(d, i) {
-      if (d.label && barColors[d.label]) {
+    return function(d) {
+      if (!Ember.isNone(d.label)) {
         return barColors[d.label];
       } else {
-        return fnGetSeriesColor(d, i);
+        return barColors[d];
       }
     };
   }),

--- a/bower.json
+++ b/bower.json
@@ -30,6 +30,7 @@
     "font-awesome": "~3.2.1",
     "ember-qunit-builds": "~0.4.0",
     "d3": "~3.5.3",
-    "lodash": "~3.10.0"
+    "lodash": "~3.10.0",
+    "tinycolor": "~1.4.1"
   }
 }

--- a/tests/unit/vertical-bar-test.js
+++ b/tests/unit/vertical-bar-test.js
@@ -142,6 +142,16 @@ test('Stacked bar chart data is sorted correctly', function(assert) {
   });
 });
 
+const checkBarLabelMappingToClass = function(testContext, assert, stackBars) {
+  testContext.subject({data: labelClassMappingTestData});
+  testContext.render();
+  var labelIDMapping = testContext.subject().get('labelIDMapping');
+
+  assert.equal(testContext.$().find(".grouping-" + labelIDMapping[label1]).length, 1, 'label1 has one section');
+  assert.equal(testContext.$().find(".grouping-" + labelIDMapping[label2]).length, 2, 'label2 has two sections');
+  assert.equal(testContext.$().find(".grouping-" + labelIDMapping[label3]).length, 2, 'label3 has two sections');
+};
+
 // https://github.com/Addepar/ember-charts/issues/172
 //
 // The root cause of problem 2 was that when some data groups have fewer data than others,
@@ -152,24 +162,12 @@ test('Stacked bar chart data is sorted correctly', function(assert) {
 test('Bug 172 Problem 2: Bars get style classes corresponding to their bar label, ' +
      'regardless of what bar group they belong to',
 function(assert) {
-  this.subject({data: labelClassMappingTestData});
-  this.render();
-  var labelIDMapping = this.subject().get('labelIDMapping');
-
-  assert.equal(this.$().find(".grouping-" + labelIDMapping[label1]).length, 1, 'label1 has one section');
-  assert.equal(this.$().find(".grouping-" + labelIDMapping[label2]).length, 2, 'label2 has two sections');
-  assert.equal(this.$().find(".grouping-" + labelIDMapping[label3]).length, 2, 'label3 has two sections');
+  checkBarLabelMappingToClass(this, assert, false);
 });
 
 test('Slices in stacked bars get style classes corresponding to their slice label',
 function(assert) {
-  this.subject({stackBars: true, data: labelClassMappingTestData});
-  this.append();
-  var labelIDMapping = this.subject().get('labelIDMapping');
-
-  assert.equal(this.$().find(".grouping-" + labelIDMapping[label1]).length, 1, 'label1 has one section');
-  assert.equal(this.$().find(".grouping-" + labelIDMapping[label2]).length, 2, 'label2 has two sections');
-  assert.equal(this.$().find(".grouping-" + labelIDMapping[label3]).length, 2, 'label3 has two sections');
+  checkBarLabelMappingToClass(this, assert, true);
 });
 
 // https://github.com/Addepar/ember-charts/issues/172


### PR DESCRIPTION
**Bug #172 - refer to that for description of the bug, including problem 1 and problem 2.**

For problem 1 (wrong bar colors), we create a permanent mapping from bar labels to bar color strings, instead of using the index of the bar datum in the bar group data array. If that array was shorter than the total number of bar labels (that is, if that bar group lacked some bars that other groups had), then there would be more colors in the palette than bars in the group, and that caused the problem. The comment in the code explains this in more detail.

For problem 2 (wrong bars being highlighted on legend mouse hover), we use a pre-existing mapping from bar labels to bar style classes. This mapping was already being used in the stacked bar chart case (`stackBars = true`), which explains why this problem didn't repro in stacked bar charts. All we have to do is use that mapping for unstacked bar charts also.

----------

**NEW TEST CODE DEPENDENCY ADDED: [tinycolor.js](https://github.com/bgrins/TinyColor)**

To make comparing colors with different color strings easier, I now import the _tinycolor.js_ library for the test code. This library has no dependencies of its own, so adding it should be relatively low-risk, but "relatively" is the important word. I make sure to import this library only in the "devDependencies" in Bower, so hopefully it will not leak into the distributed module script.

----------

As an aside, it seems odd that while we use bar style classes to implement bar highlighting, bar coloring is done individually for every bar by setting the `<rect style="...">` attribute to a style rule string.

It seems that both bar highlighting and bar coloring could be implemented with style classes, as both are based on the bar label; we could do this by generating style rules at runtime that map bars with a given label to a particular color.

While this change would be a good idea, it's arguably a bigger refactor than I want to undertake here (but Billy and I may want to do it for the new stacked bar chart code).

----------
Testing: all tests pass including new ones for problems 1 and 2
Nominated reviewers: @billylittlefield @Addepar/fire
Work item: #172