### PR TITLE
Fix bug in new #173 test code that deleted an old test

### DIFF
--- a/tests/unit/vertical-bar-test.js
+++ b/tests/unit/vertical-bar-test.js
@@ -143,7 +143,7 @@ test('Stacked bar chart data is sorted correctly', function(assert) {
 });
 
 const checkBarLabelMappingToClass = function(testContext, assert, stackBars) {
-  testContext.subject({data: labelClassMappingTestData});
+  testContext.subject({stackBars: stackBars, data: labelClassMappingTestData});
   testContext.render();
   var labelIDMapping = testContext.subject().get('labelIDMapping');
 


### PR DESCRIPTION
While refactoring some test code in order to respond to [a code review concern](https://github.com/Addepar/ember-charts/pull/173#discussion-diff-73972123) on pull request #173, I accidentally entirely removed a test case, ["[Unit] Vertical bar component: Stacked bars are grouped correctly"](https://github.com/Addepar/ember-charts/blob/66e8bdf0ed8bed251d8ffb9b2ae31967ef8534f0/tests/unit/vertical-bar-test.js#L141-L150), that existed prior to #173. Whoops!

More precisely, I made the old test identical to a new test in #173. The old test has been renamed to "[Unit] Vertical bar component: Slices in stacked bars get style classes corresponding to their slice label", and is [the second highlighted test in the updated file; the new test is first.](https://github.com/Addepar/ember-charts/blob/904512500ba684087519361869987331ff2a5190/tests/unit/vertical-bar-test.js#L145-L171)

The old and new test are supposed to be extremely similar but not the same, so after the bad refactor, they were supposed to share most code but actually share all code.

This checkin fixes the mistake.

Nominated reviewers: @Addepar/fire @BillyLittlefield
Testing: all tests pass (really this time, I checked in the debugger :)