### PR TITLE
Rounded Zero Percent Slice Configurations for Pie Charts

### DIFF
--- a/addon/components/pie-chart.js
+++ b/addon/components/pie-chart.js
@@ -42,6 +42,9 @@ const PieChartComponent = ChartComponent.extend(FloatingTooltipMixin,
   // will start from the 2 o'clock to 4 o'clock positions.
   rotationOffset: 1/4 * Math.PI,
 
+  // Allows the user to configure whether Rounded Zero Percent Slices should be
+  // included inside of the Pie Chart. For example, if maxDecimalPlace = 0 and
+  // there was a slice of 0.3%, that slice would be rounded down to 0%
   includeRoundedZeroPercentSlices: true,
 
   // ----------------------------------------------------------------------------
@@ -172,6 +175,7 @@ const PieChartComponent = ChartComponent.extend(FloatingTooltipMixin,
       }
     }
 
+    // Round all slices to the appropriate decimal place
     var maxDecimalPlace = this.get('maxDecimalPlace');
     var roundSlices = function(sliceList) {
       sliceList.forEach(function(slice) {
@@ -182,6 +186,7 @@ const PieChartComponent = ChartComponent.extend(FloatingTooltipMixin,
     roundSlices(slicesLeft);
     roundSlices(otherItems);
 
+    // Filter zero percent slices out of the pie chart after they have been rounded
     var filterRoundedZeroPercentSlices = function(sliceList) {
       return sliceList.filter(function(slice) {
         return slice.percent !== 0;

--- a/tests/acceptance/pie-test.js
+++ b/tests/acceptance/pie-test.js
@@ -107,6 +107,6 @@ test('select data: bad_range', function(assert) {
   assert.expect(1);
   fillIn(emberSelectFor('data'), 'bad_range');
   andThen(function() {
-    assert.equal(countArcs(), 3);
+    assert.equal(countArcs(), 4);
   });
 });

--- a/tests/dummy/app/controllers/pie.js
+++ b/tests/dummy/app/controllers/pie.js
@@ -23,6 +23,8 @@ import contains_zero from '../models/single_group/contains_zero';
 import large_other_small_normal_slices from '../models/single_group/large_other_small_normal_slices';
 import one_very_large_slice from '../models/single_group/one_very_large_slice';
 import hard_range_2 from '../models/single_group/hard_range_2';
+import tiny_slice_one from '../models/single_group/tiny_slice_one';
+import tiny_slice_two from '../models/single_group/tiny_slice_two';
 
 
 export default SlideController.extend({
@@ -36,6 +38,7 @@ export default SlideController.extend({
   maxRadius: 250,
   labelWidthMultiplier: 0.25,
   maxDecimalPlace: 0,
+  includeRoundedZeroPercentSlices: true,
 
   // ---------
   // Data Selection
@@ -50,19 +53,19 @@ export default SlideController.extend({
   }),
 
   rawDataHash: Ember.computed(function() {
-  	return {
-	    asset_values: asset_values,
-	    many_values: many_values,
-	    monthly_return_single_period: monthly_return_single_period,
-	    high_net_worth_duration: high_net_worth_duration,
-	    '----': data.null,
-	    empty: data.empty,
-	    one_value: one_value,
-	    two_values: two_values,
-	    zero: zero,
-	    zeroes: zeroes,
-	    sum_to_zero: sum_to_zero,
-	    bad_range: bad_range,
+    return {
+      asset_values: asset_values,
+      many_values: many_values,
+      monthly_return_single_period: monthly_return_single_period,
+      high_net_worth_duration: high_net_worth_duration,
+      '----': data.null,
+      empty: data.empty,
+      one_value: one_value,
+      two_values: two_values,
+      zero: zero,
+      zeroes: zeroes,
+      sum_to_zero: sum_to_zero,
+      bad_range: bad_range,
       has_zero_and_decimal_value: has_zero_and_decimal_value,
       high_density_small_value_labels: high_density_small_value_labels,
       many_small_one_large: many_small_one_large,
@@ -71,7 +74,9 @@ export default SlideController.extend({
       contains_zero: contains_zero,
       large_other_small_normal_slices: large_other_small_normal_slices,
       one_very_large_slice: one_very_large_slice,
-      hard_range_2: hard_range_2
+      hard_range_2: hard_range_2,
+      tiny_slice_one: tiny_slice_one,
+      tiny_slice_two: tiny_slice_two
     };
   }),
 

--- a/tests/dummy/app/models/single_group/tiny_slice_one.js
+++ b/tests/dummy/app/models/single_group/tiny_slice_one.js
@@ -1,0 +1,13 @@
+export default [{
+    label: "Label 1",
+    value: 25.3,
+    type: "percent"
+  }, {
+    label: "Label 2",
+    value: 74.4,
+    type: "percent"
+  }, {
+    label: "Label 3",
+    value: 0.3,
+    type: "percent"
+}];

--- a/tests/dummy/app/models/single_group/tiny_slice_two.js
+++ b/tests/dummy/app/models/single_group/tiny_slice_two.js
@@ -1,0 +1,17 @@
+export default [{
+    label: "Label 1",
+    value: 25.3,
+    type: "percent"
+  }, {
+    label: "Label 2",
+    value: 74.4,
+    type: "percent"
+  }, {
+    label: "Label 3",
+    value: 0.1,
+    type: "percent"
+  }, {
+    label: "Label 4",
+    value: 0.2,
+    type: "percent"
+}];

--- a/tests/dummy/app/templates/pie.hbs
+++ b/tests/dummy/app/templates/pie.hbs
@@ -14,6 +14,7 @@
         data=data
         labelWidthMultiplier=labelWidthMultiplier
         maxDecimalPlace=maxDecimalPlace
+        includeRoundedZeroPercentSlices=includeRoundedZeroPercentSlices
       }}
     </div>
   </div>
@@ -76,6 +77,19 @@
           <div class="col-lg-8">
             {{scrubber-component min="0" max="8" step="1" value=maxDecimalPlace}}
             <span class="help-block">Maximum Decimal Place: {{maxDecimalPlace}}</span>
+          </div>
+        </div>
+        <div class="form-group">
+          <div class="col-lg-offset-4 col-lg-8">
+            <div class="checkbox">
+              <label>
+                {{input
+                  type="checkbox"
+                  checked=includeRoundedZeroPercentSlices
+                }}
+                Include Rounded Zero Percent Slices
+              </label>
+            </div>
           </div>
         </div>
       </div>

--- a/tests/unit/pie-test.js
+++ b/tests/unit/pie-test.js
@@ -153,7 +153,7 @@ test('Pie with large other slice', function(assert) {
 
   assert.equal(finishedData.length, 8, 'There are 8 slices by default');
   assert.equal(_.last(finishedData).label, 'Other', 'Last slice is Other when the Other Slice is largest');
-  assert.equal(_.last(finishedData).percent, 34, 'Other percent equals 34');
+  assert.equal(_.last(finishedData).percent, 35, 'Other percent equals 35');
 });
 
 test('Pie with small other slice', function(assert) {
@@ -374,4 +374,71 @@ test('There are no label overlap in the pie charts', function(assert) {
 
   assertNoLabelOverlap(leftPie, labelHeight);
   assertNoLabelOverlap(rightPie, labelHeight);
+});
+
+test('Rounded zero percent slices appear by default', function(assert) {
+  //-------------------- Begin Setup ------------------------//
+  var pieTinySlices = {
+    maxRadius: 200,
+    maxNumberOfSlices: 10,
+    minSlicePercent: 3,
+    maxDecimalPlace: 0,
+    data: [{
+      label: "Label 1",
+      value: 25.3,
+    }, {
+      label: "Label 2",
+      value: 74.4,
+    }, {
+      label: "Label 3",
+      value: 0.1,
+    }, {
+      label: "Label 4",
+      value: 0.2,
+    }]
+  };
+
+  var component = this.subject(pieTinySlices);
+  const labels = this.$().find('.data');
+
+  var zeroPercentSlicePresent = false;
+  for (var i = 0; i < labels.length; i++) {
+    var element = labels[i];
+    if (element.textContent.includes(", 0%"))
+      zeroPercentSlicePresent = true;
+  }
+  assert.ok(zeroPercentSlicePresent);
+});
+
+test('Rounded zero percent slices can be toggled off', function(assert) {
+  //-------------------- Begin Setup ------------------------//
+  var pieTinySlices = {
+    maxRadius: 200,
+    maxNumberOfSlices: 10,
+    minSlicePercent: 3,
+    maxDecimalPlace: 0,
+    includeRoundedZeroPercentSlices: false,
+    data: [{
+      label: "Label 1",
+      value: 25.3,
+    }, {
+      label: "Label 2",
+      value: 74.4,
+    }, {
+      label: "Label 3",
+      value: 0.3,
+    }]
+  };
+
+  var component = this.subject(pieTinySlices);
+  const labels = this.$().find('.data');
+
+  var zeroPercentSlicePresent = false;
+  for (var i = 0; i < labels.length; i++) {
+    var element = labels[i];
+    if ((element.textContent.includes("Label 3")) ||
+        (element.textContent.includes(", 0%")))
+      zeroPercentSlicePresent = true;
+  }
+  assert.ok(zeroPercentSlicePresent === false);
 });

--- a/tests/unit/pie-test.js
+++ b/tests/unit/pie-test.js
@@ -404,7 +404,7 @@ test('Rounded zero percent slices appear by default', function(assert) {
   var zeroPercentSlicePresent = false;
   for (var i = 0; i < labels.length; i++) {
     var element = labels[i];
-    if (element.textContent.includes(", 0%"))
+    if (element.textContent === "Other, 0%")
       zeroPercentSlicePresent = true;
   }
   assert.ok(zeroPercentSlicePresent);
@@ -436,8 +436,7 @@ test('Rounded zero percent slices can be toggled off', function(assert) {
   var zeroPercentSlicePresent = false;
   for (var i = 0; i < labels.length; i++) {
     var element = labels[i];
-    if ((element.textContent.includes("Label 3")) ||
-        (element.textContent.includes(", 0%")))
+    if (element.textContent === "Label 3, 0%")
       zeroPercentSlicePresent = true;
   }
   assert.ok(zeroPercentSlicePresent === false);


### PR DESCRIPTION
This branch fixes rounding errors and adds the missing Other Slice when the Other Slice is incorrectly rounded to 0%. It also adds a toggle to allow users to include / exclude zero percent slices. These 0% slices respect slice ordering and number of decimal points. Finally, it contains tests for all of the above.

See screenshots for examples

With "Include Rounded Zero Percent Slice" Off
<img width="1440" alt="screenshot 2016-08-25 21 29 29" src="https://cloud.githubusercontent.com/assets/14004102/17994142/17c632c8-6b0b-11e6-823c-f1556a025314.png">

With "Include Rounded Zero Percent Slice" On (Default)
<img width="1440" alt="screenshot 2016-08-25 21 29 33" src="https://cloud.githubusercontent.com/assets/14004102/17994153/1bebdeac-6b0b-11e6-9145-819599738254.png">

With decimal places inside the Pie Chart
<img width="1440" alt="screenshot 2016-08-25 21 29 37" src="https://cloud.githubusercontent.com/assets/14004102/17994160/3261ff54-6b0b-11e6-9066-9045062745f6.png">

