### PR TITLE
Fix #173 regression: Vertical Bar Charts ignore bar-specific color overrides

### DIFF
--- a/addon/components/vertical-bar-chart.js
+++ b/addon/components/vertical-bar-chart.js
@@ -411,7 +411,9 @@ const VerticalBarChartComponent = ChartComponent.extend(LegendMixin,
   fnGetBarColor: Ember.computed('barColors', function() {
     var barColors = this.get('barColors');
     return function(d) {
-      if (!Ember.isNone(d.label)) {
+      if (!Ember.isNone(d.color)) {
+        return d.color;
+      } else if (!Ember.isNone(d.label)) {
         return barColors[d.label];
       } else {
         return barColors[d];

--- a/tests/unit/vertical-bar-test.js
+++ b/tests/unit/vertical-bar-test.js
@@ -211,3 +211,28 @@ function(assert) {
         ", which is the color in the legend for bar label " + label);
   });
 });
+
+test('Pull Request #182: A bar-specific color override is respected', function(assert) {
+  const chartBaseColor = 'rgb(65, 65, 65)';
+  const barOverrideColor = tinycolor('red').toRgbString();
+  var testData, component, actualBarColors;
+
+  assert.expect(1);
+  testData = _.cloneDeep(threeRanges);
+  testData[0].color = barOverrideColor;
+
+  component = this.subject({
+    data: testData,
+    selectedSeedColor: chartBaseColor,
+  });
+  this.render();
+
+  actualBarColors = component.$('svg rect').map(function() {
+    return tinycolor($(this).css('fill')).toRgbString();
+  });
+  assert.notEqual(
+    actualBarColors.toArray().indexOf(barOverrideColor),
+    -1,
+    "There is a bar in the chart with the correct override color " + barOverrideColor
+  );
+});


### PR DESCRIPTION
For each bar data point in a vertical bar chart, you can specify the color for that bar explicitly. This feature should be documented in the API here:
http://opensource.addepar.com/ember-charts/#/documentation
under Vertical-Bar Options, **data** property, but unfortunately the documentation is currently missing this information.

Unfortunately, pull request #173 caused us to ignore these colors. We didn't discover this bug until we tried to wire up a build of Ember Charts with #173 to Addepar's own application. Bad, very bad of us, and we are sorry.

This changeset fixes the regression. A new test is added to catch it.

Nominated reviewers: @BillyLittlefield @Addepar/fire