### PR TITLE
don't modify attributes during render cycle

### DIFF
--- a/addon/components/chart-component.js
+++ b/addon/components/chart-component.js
@@ -240,8 +240,10 @@ const ChartComponent = Ember.Component.extend(ColorableMixin, ResizeHandlerMixin
 
   didInsertElement: function() {
     this._super();
-    this._updateDimensions();
-    this.drawOnce();
+    Ember.run.scheduleOnce('afterRender', this, function() {
+      this._updateDimensions();
+      this.drawOnce();
+    });
   },
 
   drawOnce: function() {


### PR DESCRIPTION
Fixes (or at least improves) https://github.com/Addepar/ember-charts/issues/155
Alternately, the update could happen before render cycle (e.g. using an observer).
