### PR TITLE
Fix release config to update all files containing version number

### DIFF
--- a/.release.json
+++ b/.release.json
@@ -3,12 +3,15 @@
   "dry-run": false,
   "verbose": false,
   "force": false,
-  "pkgFiles": ["package.json"],
+  "pkgFiles": ["package.json","bower.json"],
   "increment": "patch",
   "commitMessage": "Release %s",
   "tagName": "v%s",
   "tagAnnotation": "Release %s",
   "buildCommand": "ember build --environment='production'",
+  "src": {
+    "beforeStageCommand": "node update-version.js"
+  },
   "dist": {
     "repo": "git@github.com:addepar/ember-charts.git#gh-pages",
     "stageDir": ".stage",

--- a/README.md
+++ b/README.md
@@ -125,8 +125,8 @@ git repository.
 If you want to control the version number, use these options:
 
 ```bash
-release-it minor # 1.2.3 -> 2.0.0
-release-it major # 1.2.3 -> 1.3.0
+release-it major # 1.2.3 -> 2.0.0
+release-it minor # 1.2.3 -> 1.3.0
 release-it X.Y.Z # 1.2.3 -> X.Y.Z
 ```
 

--- a/update-version.js
+++ b/update-version.js
@@ -1,0 +1,26 @@
+
+/**
+ * Ember-charts previously relied on a grunt task to increment the version
+ * number found in the 'VERSION' file using the grunt-text-replace plugin.
+ * When removing grunt, we lost this auto-incrementing functionality.
+ * The new `release-it` node package can handle updating our version numbers
+ * in `package.json` and `bower.json`, but is incapable of updating the
+ * `VERSION` file because it does not follow JSON key-value formatting.
+ *
+ * This custom helper is run by `release-it` prior to committing the release
+ * but after bumping the version in `package.json`. It pulls the updated
+ * version and uses this to rewrite the `VERSION` file.
+ */
+(function() {
+  'use strict';
+
+  var fs   = require('fs'),
+      path = require('path');
+
+  function getNewVersion() {
+    var packageJson = fs.readFileSync(path.resolve('package.json'))
+    return JSON.parse(packageJson).version.toString();
+  }
+
+  fs.writeFileSync(path.resolve('VERSION'), getNewVersion() + "\n");
+}());


### PR DESCRIPTION
Previously, we relied on a grunt task to update the version number in our "VERSION" file every time `grunt dist` was run (which occurred whenever we used the `grunt release-it` plug-in). By removing grunt, we lost this functionality.

This changes adds a script that gets run by `release-it` prior to committing and pushing a new release. The script automatically pulls the updated version number and overwrites the "VERSION" file with this updated version. 

Additionally, this PR adds "bower.json" back to the list of places to update version numbers (this had been removed during the move to Ember-CLI app, and has been updated manually since then).