### PR TITLE
restrict svg text styling to chart viewport

### DIFF
--- a/addon/styles/addon.less
+++ b/addon/styles/addon.less
@@ -37,7 +37,7 @@ svg {
     }
   }
 
-  text {
+  .chart-viewport text {
     cursor: default;
     fill: @label-color;
     font-size: @font-size;


### PR DESCRIPTION
This change allows users to have non-Ember Charts SVGs on their page without the these text styles overriding attribute styles.