### PR TITLE
Make hasLegend in TimeSeriesChart show legend for one item

### DIFF
--- a/addon/components/time-series-chart.js
+++ b/addon/components/time-series-chart.js
@@ -770,7 +770,7 @@ const TimeSeriesChartComponent = ChartComponent.extend(LegendMixin,
   // ----------------------------------------------------------------------------
 
   hasLegend: Ember.computed( 'legendItems.length', 'showLegend', function() {
-    return this.get('legendItems.length') > 1 && this.get('showLegend');
+    return this.get('legendItems.length') > 1 || this.get('showLegend');
   }),
 
   legendItems: Ember.computed('xBetweenSeriesDomain', 'xWithinGroupDomain',

--- a/addon/components/time-series-chart.js
+++ b/addon/components/time-series-chart.js
@@ -770,7 +770,7 @@ const TimeSeriesChartComponent = ChartComponent.extend(LegendMixin,
   // ----------------------------------------------------------------------------
 
   hasLegend: Ember.computed( 'legendItems.length', 'showLegend', function() {
-    return this.get('legendItems.length') > 1 || this.get('showLegend');
+    return this.get('legendItems.length') > 0 && this.get('showLegend');
   }),
 
   legendItems: Ember.computed('xBetweenSeriesDomain', 'xWithinGroupDomain',


### PR DESCRIPTION
Task: https://addepar.atlassian.net/browse/ADPR-32646
~Iverson PR: https://github.com/Addepar/Iverson/pull/6309~ (I might not do this based on discussion in the last paragraph)

There is one specific use case when we want to show a legend for one legend item. We're introducing a feature where we dynamically generate portfolio data rows based on one single metric https://addepar.atlassian.net/browse/ADPR-26610. The problem is that the title of the metric is statically defined, and the legend will not display if there is only one row. Thus, when the number of generated rows is one, the label of the row will not show up unless you hover over plot (see linked task). 

Another use case where this is affected is related to https://addepar.atlassian.net/browse/ADPR-31550. If there are multiple metrics but only one return actual data, the legend won't show because there is only one row being plotted, and the title will show "Multiple Metrics". 

Release notes: none