### PR TITLE
Restrict circle styling to chart viewport

### DIFF
--- a/addon/styles/addon.less
+++ b/addon/styles/addon.less
@@ -184,7 +184,7 @@ svg {
 // ----------------------------------------------------------------------
 
 // TODO(Louis): This is bad and needs refactoring
-circle {
+.chart-viewport circle {
   stroke-width: 1px;
   stroke: rgba(0, 0, 0, 0.1);
 }


### PR DESCRIPTION
Same problem as the SVG text styling issue (https://github.com/Addepar/ember-charts/pull/207). The CSS for `circle` is overriding the styling of my ember-svg-jar SVG's