### PR TITLE
Horizontal Bar chart has unnecessary buffer at top and bottom

### DIFF
--- a/addon/components/horizontal-bar-chart.js
+++ b/addon/components/horizontal-bar-chart.js
@@ -171,7 +171,7 @@ const HorizontalBarChartComponent = ChartComponent.extend(FloatingTooltipMixin,
     // Evenly split up height for bars with space between bars
     return d3.scale.ordinal()
       .domain(d3.range(this.get('numBars')))
-      .rangeRoundBands([0, this.get('height')], this.get('barPadding'));
+      .rangeBands([0, this.get('height')], this.get('barPadding'));
   }),
 
   // Space in pixels allocated to each bar + padding


### PR DESCRIPTION
In the horizontal bar chart, we use the method rangeRoundBands to graph the bars with bar padding. This method will introduce additional outer padding which causes the unwanted and changing buffer. I change it to rangeBands.