### PR TITLE
Horizontal bar chart with negative values does not show correctly

### DIFF
--- a/addon/components/chart-component.js
+++ b/addon/components/chart-component.js
@@ -129,7 +129,7 @@ const ChartComponent = Ember.Component.extend(ColorableMixin, ResizeHandlerMixin
   outerWidth: Ember.computed.alias('defaultOuterWidth'),
 
   width: Ember.computed('outerWidth', 'marginLeft', 'marginRight', function() {
-    return this.get('outerWidth') - this.get('marginLeft') - this.get('marginRight');
+    return Math.abs(this.get('outerWidth') - this.get('marginLeft') - this.get('marginRight'));
   }),
 
   height: Ember.computed('outerHeight', 'marginBottom', 'marginTop', function() {


### PR DESCRIPTION
It is because width could be a negative value. 
```
_xScaleForWidth: function(width) {
    return d3.scale.linear()
      .domain(this.get('xDomain'))
      .range([0, width]);
  }
```
The method uses the incorrect range to compute the X value for the bar X position.

Before: 
![image](https://user-images.githubusercontent.com/30635015/38147978-625093ce-3409-11e8-9ba2-09d509687169.png)

After:
![image](https://user-images.githubusercontent.com/30635015/38147987-6a2cfb1e-3409-11e8-9317-78521ae002a8.png)
