### PR TITLE
Make sure that width is always non-negative value.

### DIFF
--- a/addon/components/chart-component.js
+++ b/addon/components/chart-component.js
@@ -129,7 +129,7 @@ const ChartComponent = Ember.Component.extend(ColorableMixin, ResizeHandlerMixin
   outerWidth: Ember.computed.alias('defaultOuterWidth'),
 
   width: Ember.computed('outerWidth', 'marginLeft', 'marginRight', function() {
-    return this.get('outerWidth') - this.get('marginLeft') - this.get('marginRight');
+    return Math.abs(this.get('outerWidth') - this.get('marginLeft') - this.get('marginRight'));
   }),
 
   height: Ember.computed('outerHeight', 'marginBottom', 'marginTop', function() {


### PR DESCRIPTION
In some cases, `this.get('outerWidth') - this.get('marginLeft') - this.get('marginRight')` will return negative value which will cause a rendering bug. 