### PR TITLE
Bump ember-cli-babel to 6.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "ember-addon"
   ],
   "dependencies": {
-    "ember-cli-babel": "^5.0.0",
+    "ember-cli-babel": "^6.0.0",
     "ember-cli-less": "~1.3.1"
   },
   "ember-addon": {


### PR DESCRIPTION
Without this change I couldn't use ember-charts with Ember 3.5, due to the following build warning and error:

Build warning:
```
DEPRECATION: ember-cli-babel 5.x has been deprecated. Please upgrade to at least ember-cli-babel 6.6. Version 5.2.8 located: my_app -> ember-charts -> ember-cli-babel
```

Runtime error:
```
Could not find module ember imported from ember-charts/components/pie-chart
```