### PR TITLE
Use afterRender for draw calls

### DIFF
--- a/addon/components/chart-component.js
+++ b/addon/components/chart-component.js
@@ -223,6 +223,7 @@ const ChartComponent = Ember.Component.extend(ColorableMixin, ResizeHandlerMixin
 
   init: function() {
     this._super();
+    this._scheduledDrawCount = 0;
     _.uniq(this.get('renderVars')).forEach((renderVar) => {
       this.addObserver(renderVar, this.drawOnce);
       // This is just to ensure that observers added above fire even
@@ -247,7 +248,8 @@ const ChartComponent = Ember.Component.extend(ColorableMixin, ResizeHandlerMixin
   },
 
   drawOnce: function() {
-    Ember.run.once(this, this.get('draw'));
+    this._scheduledDrawCount++;
+    Ember.run.schedule('afterRender', this, this.draw);
   },
 
   onResizeEnd: function() {
@@ -266,6 +268,10 @@ const ChartComponent = Ember.Component.extend(ColorableMixin, ResizeHandlerMixin
 
   // Remove previous drawing
   draw: function() {
+    this._scheduledDrawCount--;
+    if (this._scheduledDrawCount > 0) {
+      return;
+    }
     if ((this._state || this.state) !== "inDOM") {
       return;
     }


### PR DESCRIPTION
There were two downsides to how thie scheduling of draw was implemented. First, scheduling into actions means the drawing will occur before the next rendering pass. In a messy codebase the rendering pass might itself be setting state, so we may want to go after it. Second, the `once` method will always execute on the first scheduled task. If a property changes three times and each time a) schedules draw and b) schedules another task you will end up executing draw,task,task,task when what you want is task,task,task,draw. This can also happen if property changes interleave in the actions queue with the draw tasks.

This implementation moved to afterRender which is less efficient but defensive. It also uses a strategy for running draw once which defers drawing until the last possible entry in the queue.