### PR TITLE
Use afterRender for dimensions measurements

### DIFF
--- a/addon/components/chart-component.js
+++ b/addon/components/chart-component.js
@@ -242,6 +242,9 @@ const ChartComponent = Ember.Component.extend(ColorableMixin, ResizeHandlerMixin
   didInsertElement: function() {
     this._super();
     Ember.run.scheduleOnce('afterRender', this, function() {
+      if (this.isDestroying || !this.element) {
+        return;
+      }
       this._updateDimensions();
       this.drawOnce();
     });

--- a/addon/components/horizontal-bar-chart.js
+++ b/addon/components/horizontal-bar-chart.js
@@ -346,10 +346,10 @@ const HorizontalBarChartComponent = ChartComponent.extend(FloatingTooltipMixin,
 
   didInsertElement: function() {
     this._super(...arguments);
-    // TODO (philn): This `Ember.run.next` was added to fix a bug where
-    // a horizontal bar chart was rendered incorrectly the first time, but
-    // correctly on subsequent renders. Still not entirely clear why that is.
-    this._scheduledRedraw = Ember.run.next( () => {
+    this._scheduledRedraw = Ember.run.schedule( 'afterRender', () => {
+      if (this.isDestroying || !this.element) {
+        return;
+      }
       this._updateDimensions();
       this.drawOnce();
     });


### PR DESCRIPTION
Use `afterRender` queue for measurement, and additionally confirm the lifecycle of the instance and its rendering before attempting to measure.