### PR TITLE
[BUG] Check first if a CP has been computed

### DIFF
--- a/addon/components/bubble-chart.js
+++ b/addon/components/bubble-chart.js
@@ -69,10 +69,12 @@ export default ChartComponent.extend(FloatingTooltipMixin, {
   }),
 
   willDestroyElement: function() {
-    let vis = this.get('viewport');
-    let circles = vis.selectAll("circle");
-    circles.on('mouseover', null);
-    circles.on('mouseout', null);
+    if(this._hasMouseEventListeners) {
+      let vis = this.get('viewport');
+      let circles = vis.selectAll("circle");
+      circles.on('mouseover', null);
+      circles.on('mouseout', null);
+    }
 
     this._super(...arguments);
   },
@@ -129,6 +131,7 @@ export default ChartComponent.extend(FloatingTooltipMixin, {
     var showDetails = this.get('showDetails');
     var hideDetails = this.get('hideDetails');
     var fill_color = this.get('getSeriesColor');
+    this._hasMouseEventListeners = true;
 
     var circles = vis.selectAll("circle")
       .data(nodes, (d) => d.id);

--- a/addon/components/horizontal-bar-chart.js
+++ b/addon/components/horizontal-bar-chart.js
@@ -360,9 +360,11 @@ const HorizontalBarChartComponent = ChartComponent.extend(FloatingTooltipMixin,
    * @override
    */
   willDestroyElement: function() {
-    let groups = this.get('groups');
-    groups.on('mouseover', null);
-    groups.on('mouseout', null);
+    if(this._hasMouseEventListeners) {
+      let groups = this.get('groups');
+      groups.on('mouseover', null);
+      groups.on('mouseout', null);
+    }
     Ember.run.cancel(this._scheduledRedraw);
     this._super(...arguments);
   },
@@ -398,6 +400,7 @@ const HorizontalBarChartComponent = ChartComponent.extend(FloatingTooltipMixin,
     var groups = this.get('groups');
     var showDetails = this.get('showDetails');
     var hideDetails = this.get('hideDetails');
+    this._hasMouseEventListeners = true;
 
     var entering = groups.enter()
       .append('g').attr('class', 'bar')

--- a/addon/components/pie-chart.js
+++ b/addon/components/pie-chart.js
@@ -48,9 +48,11 @@ const PieChartComponent = ChartComponent.extend(FloatingTooltipMixin,
   includeRoundedZeroPercentSlices: true,
 
   willDestroyElement: function() {
-    let groups = this.get('groups');
-    groups.on('mouseover', null);
-    groups.on('mouseout', null);
+    if(this._hasMouseEventListeners) {
+      let groups = this.get('groups');
+      groups.on('mouseover', null);
+      groups.on('mouseout', null);
+    }
     this._super(...arguments);
   },
 
@@ -593,6 +595,7 @@ const PieChartComponent = ChartComponent.extend(FloatingTooltipMixin,
     groups = this.get('groups');
     showDetails = this.get('showDetails');
     hideDetails = this.get('hideDetails');
+    this._hasMouseEventListeners = true;
     entering = groups.enter().append('g').attr({
       "class": 'arc'
     }).on("mouseover", function(d, i) {

--- a/addon/components/scatter-chart.js
+++ b/addon/components/scatter-chart.js
@@ -62,13 +62,16 @@ const ScatterChartComponent = ChartComponent.extend(LegendMixin, FloatingTooltip
   hasYDomainPadding: true,
 
   willDestroyElement: function() {
-    let groups = this.get('groups');
-    groups.on('mouseover', null);
-    groups.on('mouseout', null);
+    if(this._hasMouseEventListeners) {
+      let groups = this.get('groups');
+      groups.on('mouseover', null);
+      groups.on('mouseout', null);
 
-    let totalGroup = this.get('viewport').select('.totalgroup');
-    totalGroup.on('mouseover', null);
-    totalGroup.on('mouseout', null);
+      let viewport = this.get('viewport');
+      let totalGroup = viewport.select('.totalgroup');
+      totalGroup.on('mouseover', null);
+      totalGroup.on('mouseout', null);
+    }
 
     this._super(...arguments);
   },
@@ -525,6 +528,7 @@ const ScatterChartComponent = ChartComponent.extend(LegendMixin, FloatingTooltip
   updateGraphic: function() {
     var showDetails = this.get('showDetails');
     var hideDetails = this.get('hideDetails');
+    this._hasMouseEventListeners = true;
 
     this.get('groups')
       .selectAll('.dot')

--- a/addon/components/stacked-vertical-bar-chart.js
+++ b/addon/components/stacked-vertical-bar-chart.js
@@ -98,13 +98,15 @@ const StackedVerticalBarChartComponent = ChartComponent.extend(LegendMixin,
 
 
   willDestroyElement: function() {
-    let bars = this.get('bars');
-    bars.on('mouseover', null);
-    bars.on('mouseout', null);
+    if(this._hasMouseEventListeners) {
+      let bars = this.get('bars');
+      bars.on('mouseover', null);
+      bars.on('mouseout', null);
 
-    let slices = bars.selectAll('rect');
-    slices.on('mouseover', null);
-    slices.on('mouseout', null);
+      let slices = bars.selectAll('rect');
+      slices.on('mouseover', null);
+      slices.on('mouseout', null);
+    }
 
     this._super(...arguments);
   },
@@ -963,6 +965,7 @@ const StackedVerticalBarChartComponent = ChartComponent.extend(LegendMixin,
     var bars = this.get('bars');
     var showDetails = this.get('showDetails');
     var hideDetails = this.get('hideDetails');
+    this._hasMouseEventListeners = true;
 
     var entering = bars.enter()
       .append('g').attr('class', 'bars');

--- a/addon/components/time-series-chart.js
+++ b/addon/components/time-series-chart.js
@@ -62,10 +62,7 @@ const TimeSeriesChartComponent = ChartComponent.extend(LegendMixin,
   xAxisVertLabels: false,
 
   willDestroyElement: function() {
-    var groups = this.get('groups');
-    var bars = groups.selectAll('rect');
-    bars.on('mouseover', null);
-    bars.on('mouseout', null);
+    this._removeMouseEventListeners();
 
     this._super(...arguments);
   },
@@ -819,7 +816,17 @@ const TimeSeriesChartComponent = ChartComponent.extend(LegendMixin,
   // ----------------------------------------------------------------------------
 
   removeAllGroups: function() {
+    this._removeMouseEventListeners();
     this.get('viewport').selectAll('.bars').remove();
+  },
+
+  _removeMouseEventListeners: function() {
+    if(this._hasMouseEventListeners) {
+      let groups = this.get('groups');
+      let bars = groups.selectAll('rect');
+      bars.on('mouseover', null);
+      bars.on('mouseout', null);
+    }
   },
 
   groups: Ember.computed(function() {
@@ -957,6 +964,7 @@ const TimeSeriesChartComponent = ChartComponent.extend(LegendMixin,
     var groups = this.get('groups');
     var showDetails = this.get('showDetails');
     var hideDetails = this.get('hideDetails');
+    this._hasMouseEventListeners = true;
 
     // Ensure bars are always inserted behind lines
     groups.enter()

--- a/addon/components/vertical-bar-chart.js
+++ b/addon/components/vertical-bar-chart.js
@@ -54,13 +54,15 @@ const VerticalBarChartComponent = ChartComponent.extend(LegendMixin,
   maxLabelHeight: 50,
 
   willDestroyElement: function() {
-    let groups = this.get('groups');
-    groups.on('mouseover', null);
-    groups.on('mouseout', null);
+    if(this._hasMouseEventListeners) {
+      let groups = this.get('groups');
+      groups.on('mouseover', null);
+      groups.on('mouseout', null);
 
-    let bars = groups.selectAll('rect');
-    bars.on('mouseover', null);
-    bars.on('mouseout', null);
+      let bars = groups.selectAll('rect');
+      bars.on('mouseover', null);
+      bars.on('mouseout', null);
+    }
 
     this._super(...arguments);
   },
@@ -734,6 +736,7 @@ const VerticalBarChartComponent = ChartComponent.extend(LegendMixin,
     var groups = this.get('groups');
     var showDetails = this.get('showDetails');
     var hideDetails = this.get('hideDetails');
+    this._hasMouseEventListeners = true;
 
     var entering = groups.enter()
       .append('g').attr('class', 'bars');

--- a/addon/mixins/has-time-series-rule.js
+++ b/addon/mixins/has-time-series-rule.js
@@ -32,9 +32,12 @@ export default Ember.Mixin.create({
   graphicHeight: null,
 
   willDestroyElement: function() {
-    let lineMarkers = this._getLineMarkers();
-    lineMarkers.on('mouseover', null);
-    lineMarkers.on('mouseout', null);
+    if(this._hasMouseEventListeners) {
+      let lineMarkers = this._getLineMarkers();
+      lineMarkers.on('mouseover', null);
+      lineMarkers.on('mouseout', null);
+    }
+
     this._super(...arguments);
   },
 
@@ -46,6 +49,7 @@ export default Ember.Mixin.create({
     var lineMarkers = this._getLineMarkers();
     var showDetails = this.get('showDetails');
     var hideDetails = this.get('hideDetails');
+    this._hasMouseEventListeners = true;
 
     lineMarkers.enter()
       .append('path')

--- a/addon/mixins/legend.js
+++ b/addon/mixins/legend.js
@@ -78,10 +78,12 @@ export default Ember.Mixin.create({
   showLegend: true,
 
   willDestroyElement: function() {
-    let legend = this.get('legend');
-    let legendItems = legend.selectAll('.legend-item');
-    legendItems.on('mouseover', null);
-    legendItems.on('mouseout', null);
+    if(this._hasMouseEventListeners) {
+      let legend = this.get('legend');
+      let legendItems = legend.selectAll('.legend-item');
+      legendItems.on('mouseover', null);
+      legendItems.on('mouseout', null);
+    }
     this._super(...arguments);
   },
 
@@ -343,6 +345,7 @@ export default Ember.Mixin.create({
 
     var showLegendDetails = this.get('showLegendDetails');
     var hideLegendDetails = this.get('hideLegendDetails');
+    this._hasMouseEventListeners = true;
     var legendItems =
       legend.selectAll('.legend-item')
             .data(this.get('legendItems'))

--- a/addon/mixins/pie-legend.js
+++ b/addon/mixins/pie-legend.js
@@ -27,9 +27,12 @@ const PieLegendMixin = Ember.Mixin.create({
   showLegend: true,
 
   willDestroyElement: function() {
-    let legend = this.get('legend');
-    legend.on('mouseover', null);
-    legend.on('mouseout', null);
+    if(this._hasMouseEventListeners) {
+      let legend = this.get('legend');
+      legend.on('mouseover', null);
+      legend.on('mouseout', null);
+    }
+
     this._super(...arguments);
   },
 
@@ -105,6 +108,7 @@ const PieLegendMixin = Ember.Mixin.create({
       return;
     }
     this.clearLegend();
+    this._hasMouseEventListeners = true;
     var legend = this.get('legend').attr(this.get('legendAttrs'));
 
     // Bind hover state to the legend


### PR DESCRIPTION
When removing memory leaks in #231, I assumed that the CPs that were used to attach event handlers were always computed. It turns out it's not the case. In this PR a flag is used to track when an event listener is added, then that same flag is checked to determine if teardown is required.