### PR TITLE
Revert "[BUG] Don't trigger unnecessary computation during teardown"

### DIFF
--- a/addon/components/bubble-chart.js
+++ b/addon/components/bubble-chart.js
@@ -68,16 +68,6 @@ export default ChartComponent.extend(FloatingTooltipMixin, {
     };
   }),
 
-  willDestroyElement: function() {
-    let vis = this.get('viewport');
-    let circles = vis.selectAll("circle");
-    circles.on('mouseover', null);
-    circles.on('mouseout', null);
-
-    this._super(...arguments);
-  },
-
-
   // ----------------------------------------------------------------------------
   // Data
   // ----------------------------------------------------------------------------

--- a/addon/components/bubble-chart.js
+++ b/addon/components/bubble-chart.js
@@ -69,12 +69,10 @@ export default ChartComponent.extend(FloatingTooltipMixin, {
   }),
 
   willDestroyElement: function() {
-    if(this._hasMouseEventListeners) {
-      let vis = this.get('viewport');
-      let circles = vis.selectAll("circle");
-      circles.on('mouseover', null);
-      circles.on('mouseout', null);
-    }
+    let vis = this.get('viewport');
+    let circles = vis.selectAll("circle");
+    circles.on('mouseover', null);
+    circles.on('mouseout', null);
 
     this._super(...arguments);
   },
@@ -131,7 +129,6 @@ export default ChartComponent.extend(FloatingTooltipMixin, {
     var showDetails = this.get('showDetails');
     var hideDetails = this.get('hideDetails');
     var fill_color = this.get('getSeriesColor');
-    this._hasMouseEventListeners = true;
 
     var circles = vis.selectAll("circle")
       .data(nodes, (d) => d.id);

--- a/addon/components/horizontal-bar-chart.js
+++ b/addon/components/horizontal-bar-chart.js
@@ -360,11 +360,9 @@ const HorizontalBarChartComponent = ChartComponent.extend(FloatingTooltipMixin,
    * @override
    */
   willDestroyElement: function() {
-    if(this._hasMouseEventListeners) {
-      let groups = this.get('groups');
-      groups.on('mouseover', null);
-      groups.on('mouseout', null);
-    }
+    let groups = this.get('groups');
+    groups.on('mouseover', null);
+    groups.on('mouseout', null);
     Ember.run.cancel(this._scheduledRedraw);
     this._super(...arguments);
   },
@@ -400,7 +398,6 @@ const HorizontalBarChartComponent = ChartComponent.extend(FloatingTooltipMixin,
     var groups = this.get('groups');
     var showDetails = this.get('showDetails');
     var hideDetails = this.get('hideDetails');
-    this._hasMouseEventListeners = true;
 
     var entering = groups.enter()
       .append('g').attr('class', 'bar')

--- a/addon/components/horizontal-bar-chart.js
+++ b/addon/components/horizontal-bar-chart.js
@@ -360,11 +360,8 @@ const HorizontalBarChartComponent = ChartComponent.extend(FloatingTooltipMixin,
    * @override
    */
   willDestroyElement: function() {
-    let groups = this.get('groups');
-    groups.on('mouseover', null);
-    groups.on('mouseout', null);
-    Ember.run.cancel(this._scheduledRedraw);
     this._super(...arguments);
+    Ember.run.cancel(this._scheduledRedraw);
   },
 
   /**

--- a/addon/components/pie-chart.js
+++ b/addon/components/pie-chart.js
@@ -47,13 +47,6 @@ const PieChartComponent = ChartComponent.extend(FloatingTooltipMixin,
   // there was a slice of 0.3%, that slice would be rounded down to 0%
   includeRoundedZeroPercentSlices: true,
 
-  willDestroyElement: function() {
-    let groups = this.get('groups');
-    groups.on('mouseover', null);
-    groups.on('mouseout', null);
-    this._super(...arguments);
-  },
-
   // ----------------------------------------------------------------------------
   // Data
   // ----------------------------------------------------------------------------

--- a/addon/components/pie-chart.js
+++ b/addon/components/pie-chart.js
@@ -48,11 +48,9 @@ const PieChartComponent = ChartComponent.extend(FloatingTooltipMixin,
   includeRoundedZeroPercentSlices: true,
 
   willDestroyElement: function() {
-    if(this._hasMouseEventListeners) {
-      let groups = this.get('groups');
-      groups.on('mouseover', null);
-      groups.on('mouseout', null);
-    }
+    let groups = this.get('groups');
+    groups.on('mouseover', null);
+    groups.on('mouseout', null);
     this._super(...arguments);
   },
 
@@ -595,7 +593,6 @@ const PieChartComponent = ChartComponent.extend(FloatingTooltipMixin,
     groups = this.get('groups');
     showDetails = this.get('showDetails');
     hideDetails = this.get('hideDetails');
-    this._hasMouseEventListeners = true;
     entering = groups.enter().append('g').attr({
       "class": 'arc'
     }).on("mouseover", function(d, i) {

--- a/addon/components/scatter-chart.js
+++ b/addon/components/scatter-chart.js
@@ -61,18 +61,6 @@ const ScatterChartComponent = ChartComponent.extend(LegendMixin, FloatingTooltip
   **/
   hasYDomainPadding: true,
 
-  willDestroyElement: function() {
-    let groups = this.get('groups');
-    groups.on('mouseover', null);
-    groups.on('mouseout', null);
-
-    let totalGroup = this.get('viewport').select('.totalgroup');
-    totalGroup.on('mouseover', null);
-    totalGroup.on('mouseout', null);
-
-    this._super(...arguments);
-  },
-
   // ----------------------------------------------------------------------------
   // Data
   // ----------------------------------------------------------------------------

--- a/addon/components/scatter-chart.js
+++ b/addon/components/scatter-chart.js
@@ -62,16 +62,13 @@ const ScatterChartComponent = ChartComponent.extend(LegendMixin, FloatingTooltip
   hasYDomainPadding: true,
 
   willDestroyElement: function() {
-    if(this._hasMouseEventListeners) {
-      let groups = this.get('groups');
-      groups.on('mouseover', null);
-      groups.on('mouseout', null);
+    let groups = this.get('groups');
+    groups.on('mouseover', null);
+    groups.on('mouseout', null);
 
-      let viewport = this.get('viewport');
-      let totalGroup = viewport.select('.totalgroup');
-      totalGroup.on('mouseover', null);
-      totalGroup.on('mouseout', null);
-    }
+    let totalGroup = this.get('viewport').select('.totalgroup');
+    totalGroup.on('mouseover', null);
+    totalGroup.on('mouseout', null);
 
     this._super(...arguments);
   },
@@ -528,7 +525,6 @@ const ScatterChartComponent = ChartComponent.extend(LegendMixin, FloatingTooltip
   updateGraphic: function() {
     var showDetails = this.get('showDetails');
     var hideDetails = this.get('hideDetails');
-    this._hasMouseEventListeners = true;
 
     this.get('groups')
       .selectAll('.dot')

--- a/addon/components/stacked-vertical-bar-chart.js
+++ b/addon/components/stacked-vertical-bar-chart.js
@@ -96,19 +96,6 @@ const StackedVerticalBarChartComponent = ChartComponent.extend(LegendMixin,
    */
   maxLabelHeight: 50,
 
-
-  willDestroyElement: function() {
-    let bars = this.get('bars');
-    bars.on('mouseover', null);
-    bars.on('mouseout', null);
-
-    let slices = bars.selectAll('rect');
-    slices.on('mouseover', null);
-    slices.on('mouseout', null);
-
-    this._super(...arguments);
-  },
-
   // ---------------------------------------------------------------------------
   // Data
   // ---------------------------------------------------------------------------

--- a/addon/components/stacked-vertical-bar-chart.js
+++ b/addon/components/stacked-vertical-bar-chart.js
@@ -98,15 +98,13 @@ const StackedVerticalBarChartComponent = ChartComponent.extend(LegendMixin,
 
 
   willDestroyElement: function() {
-    if(this._hasMouseEventListeners) {
-      let bars = this.get('bars');
-      bars.on('mouseover', null);
-      bars.on('mouseout', null);
+    let bars = this.get('bars');
+    bars.on('mouseover', null);
+    bars.on('mouseout', null);
 
-      let slices = bars.selectAll('rect');
-      slices.on('mouseover', null);
-      slices.on('mouseout', null);
-    }
+    let slices = bars.selectAll('rect');
+    slices.on('mouseover', null);
+    slices.on('mouseout', null);
 
     this._super(...arguments);
   },
@@ -965,7 +963,6 @@ const StackedVerticalBarChartComponent = ChartComponent.extend(LegendMixin,
     var bars = this.get('bars');
     var showDetails = this.get('showDetails');
     var hideDetails = this.get('hideDetails');
-    this._hasMouseEventListeners = true;
 
     var entering = bars.enter()
       .append('g').attr('class', 'bars');

--- a/addon/components/time-series-chart.js
+++ b/addon/components/time-series-chart.js
@@ -62,7 +62,10 @@ const TimeSeriesChartComponent = ChartComponent.extend(LegendMixin,
   xAxisVertLabels: false,
 
   willDestroyElement: function() {
-    this._removeMouseEventListeners();
+    var groups = this.get('groups');
+    var bars = groups.selectAll('rect');
+    bars.on('mouseover', null);
+    bars.on('mouseout', null);
 
     this._super(...arguments);
   },
@@ -816,17 +819,7 @@ const TimeSeriesChartComponent = ChartComponent.extend(LegendMixin,
   // ----------------------------------------------------------------------------
 
   removeAllGroups: function() {
-    this._removeMouseEventListeners();
     this.get('viewport').selectAll('.bars').remove();
-  },
-
-  _removeMouseEventListeners: function() {
-    if(this._hasMouseEventListeners) {
-      let groups = this.get('groups');
-      let bars = groups.selectAll('rect');
-      bars.on('mouseover', null);
-      bars.on('mouseout', null);
-    }
   },
 
   groups: Ember.computed(function() {
@@ -964,7 +957,6 @@ const TimeSeriesChartComponent = ChartComponent.extend(LegendMixin,
     var groups = this.get('groups');
     var showDetails = this.get('showDetails');
     var hideDetails = this.get('hideDetails');
-    this._hasMouseEventListeners = true;
 
     // Ensure bars are always inserted behind lines
     groups.enter()

--- a/addon/components/time-series-chart.js
+++ b/addon/components/time-series-chart.js
@@ -61,15 +61,6 @@ const TimeSeriesChartComponent = ChartComponent.extend(LegendMixin,
   // Force X-Axis labels to print vertically
   xAxisVertLabels: false,
 
-  willDestroyElement: function() {
-    var groups = this.get('groups');
-    var bars = groups.selectAll('rect');
-    bars.on('mouseover', null);
-    bars.on('mouseout', null);
-
-    this._super(...arguments);
-  },
-
   // ----------------------------------------------------------------------------
   // Time Series Chart Constants
   // ----------------------------------------------------------------------------
@@ -993,7 +984,7 @@ const TimeSeriesChartComponent = ChartComponent.extend(LegendMixin,
     series.enter()
       .append('g').attr('class', 'series')
       .append('path').attr('class', 'line');
-
+      
     series.exit()
       .remove();
   },

--- a/addon/components/vertical-bar-chart.js
+++ b/addon/components/vertical-bar-chart.js
@@ -53,18 +53,6 @@ const VerticalBarChartComponent = ChartComponent.extend(LegendMixin,
   // are rotated, they will be extended beyond labelHeight up to maxLabelHeight
   maxLabelHeight: 50,
 
-  willDestroyElement: function() {
-    let groups = this.get('groups');
-    groups.on('mouseover', null);
-    groups.on('mouseout', null);
-
-    let bars = groups.selectAll('rect');
-    bars.on('mouseover', null);
-    bars.on('mouseout', null);
-
-    this._super(...arguments);
-  },
-
   // ----------------------------------------------------------------------------
   // Data
   // ----------------------------------------------------------------------------

--- a/addon/components/vertical-bar-chart.js
+++ b/addon/components/vertical-bar-chart.js
@@ -54,15 +54,13 @@ const VerticalBarChartComponent = ChartComponent.extend(LegendMixin,
   maxLabelHeight: 50,
 
   willDestroyElement: function() {
-    if(this._hasMouseEventListeners) {
-      let groups = this.get('groups');
-      groups.on('mouseover', null);
-      groups.on('mouseout', null);
+    let groups = this.get('groups');
+    groups.on('mouseover', null);
+    groups.on('mouseout', null);
 
-      let bars = groups.selectAll('rect');
-      bars.on('mouseover', null);
-      bars.on('mouseout', null);
-    }
+    let bars = groups.selectAll('rect');
+    bars.on('mouseover', null);
+    bars.on('mouseout', null);
 
     this._super(...arguments);
   },
@@ -736,7 +734,6 @@ const VerticalBarChartComponent = ChartComponent.extend(LegendMixin,
     var groups = this.get('groups');
     var showDetails = this.get('showDetails');
     var hideDetails = this.get('hideDetails');
-    this._hasMouseEventListeners = true;
 
     var entering = groups.enter()
       .append('g').attr('class', 'bars');

--- a/addon/mixins/has-time-series-rule.js
+++ b/addon/mixins/has-time-series-rule.js
@@ -31,13 +31,6 @@ export default Ember.Mixin.create({
   lineColorFn: null,
   graphicHeight: null,
 
-  willDestroyElement: function() {
-    let lineMarkers = this._getLineMarkers();
-    lineMarkers.on('mouseover', null);
-    lineMarkers.on('mouseout', null);
-    this._super(...arguments);
-  },
-
   // # ----------------------------------------------------------------------
   // # Drawing Functions
   // # ----------------------------------------------------------------------

--- a/addon/mixins/has-time-series-rule.js
+++ b/addon/mixins/has-time-series-rule.js
@@ -32,12 +32,9 @@ export default Ember.Mixin.create({
   graphicHeight: null,
 
   willDestroyElement: function() {
-    if(this._hasMouseEventListeners) {
-      let lineMarkers = this._getLineMarkers();
-      lineMarkers.on('mouseover', null);
-      lineMarkers.on('mouseout', null);
-    }
-
+    let lineMarkers = this._getLineMarkers();
+    lineMarkers.on('mouseover', null);
+    lineMarkers.on('mouseout', null);
     this._super(...arguments);
   },
 
@@ -49,7 +46,6 @@ export default Ember.Mixin.create({
     var lineMarkers = this._getLineMarkers();
     var showDetails = this.get('showDetails');
     var hideDetails = this.get('hideDetails');
-    this._hasMouseEventListeners = true;
 
     lineMarkers.enter()
       .append('path')

--- a/addon/mixins/legend.js
+++ b/addon/mixins/legend.js
@@ -78,12 +78,10 @@ export default Ember.Mixin.create({
   showLegend: true,
 
   willDestroyElement: function() {
-    if(this._hasMouseEventListeners) {
-      let legend = this.get('legend');
-      let legendItems = legend.selectAll('.legend-item');
-      legendItems.on('mouseover', null);
-      legendItems.on('mouseout', null);
-    }
+    let legend = this.get('legend');
+    let legendItems = legend.selectAll('.legend-item');
+    legendItems.on('mouseover', null);
+    legendItems.on('mouseout', null);
     this._super(...arguments);
   },
 
@@ -345,7 +343,6 @@ export default Ember.Mixin.create({
 
     var showLegendDetails = this.get('showLegendDetails');
     var hideLegendDetails = this.get('hideLegendDetails');
-    this._hasMouseEventListeners = true;
     var legendItems =
       legend.selectAll('.legend-item')
             .data(this.get('legendItems'))

--- a/addon/mixins/legend.js
+++ b/addon/mixins/legend.js
@@ -77,18 +77,9 @@ export default Ember.Mixin.create({
   // if you want to override default legend behavior, override showLegend
   showLegend: true,
 
-  willDestroyElement: function() {
-    let legend = this.get('legend');
-    let legendItems = legend.selectAll('.legend-item');
-    legendItems.on('mouseover', null);
-    legendItems.on('mouseout', null);
-    this._super(...arguments);
-  },
-
   // ----------------------------------------------------------------------------
   // Layout
   // ----------------------------------------------------------------------------
-
 
   // Outside bounds of legend
   legendWidth: Ember.computed.alias('width'),

--- a/addon/mixins/pie-legend.js
+++ b/addon/mixins/pie-legend.js
@@ -27,12 +27,9 @@ const PieLegendMixin = Ember.Mixin.create({
   showLegend: true,
 
   willDestroyElement: function() {
-    if(this._hasMouseEventListeners) {
-      let legend = this.get('legend');
-      legend.on('mouseover', null);
-      legend.on('mouseout', null);
-    }
-
+    let legend = this.get('legend');
+    legend.on('mouseover', null);
+    legend.on('mouseout', null);
     this._super(...arguments);
   },
 
@@ -108,7 +105,6 @@ const PieLegendMixin = Ember.Mixin.create({
       return;
     }
     this.clearLegend();
-    this._hasMouseEventListeners = true;
     var legend = this.get('legend').attr(this.get('legendAttrs'));
 
     // Bind hover state to the legend

--- a/addon/mixins/pie-legend.js
+++ b/addon/mixins/pie-legend.js
@@ -26,13 +26,6 @@ const PieLegendMixin = Ember.Mixin.create({
   // if you want to override default legend behavior, override showLegend
   showLegend: true,
 
-  willDestroyElement: function() {
-    let legend = this.get('legend');
-    legend.on('mouseover', null);
-    legend.on('mouseout', null);
-    this._super(...arguments);
-  },
-
   // ----------------------------------------------------------------------------
   // Layout
   // ----------------------------------------------------------------------------


### PR DESCRIPTION
This reverts:

* 3926f9bb843a7dd00940ef3582449d27dba35bab, PR https://github.com/Addepar/ember-charts/pull/234.
* 27e12fa307e136d78ebd0b10f4ddff4938ac81c1, PR https://github.com/Addepar/ember-charts/pull/231.

The teardown solution used in #234 re-invokes volatile CPs. During un-rendering of an application, the invocations may attempt to calculate based on no-longer-valid state.

Furthermore afaik d3 instances should be `exit()` and `remove()`, and the handlers will be GC'd by Chrome. There is possibly something going on here and this is possibly a mitigation or fix, but neither of those PRs actually describe what is going on in more detail than "event handlers should be removed" (which is guidance that does not apply to Chrome).