### PR TITLE
Use d3 path, don't use .data( during teardown

### DIFF
--- a/addon/components/horizontal-bar-chart.js
+++ b/addon/components/horizontal-bar-chart.js
@@ -321,11 +321,13 @@ const HorizontalBarChartComponent = ChartComponent.extend(FloatingTooltipMixin,
   // ----------------------------------------------------------------------------
   // Selections
   // ----------------------------------------------------------------------------
+ 
+  getViewportBars() {
+    return this.get('viewport').selectAll('.bar');
+  },
 
   groups: Ember.computed(function() {
-    return this.get('viewport')
-      .selectAll('.bar')
-      .data(this.get('finishedData'));
+    return this.getViewportBars().data(this.get('finishedData'));
   }).volatile(),
 
   yAxis: Ember.computed(function() {
@@ -361,9 +363,9 @@ const HorizontalBarChartComponent = ChartComponent.extend(FloatingTooltipMixin,
    */
   willDestroyElement: function() {
     if(this._hasMouseEventListeners) {
-      let groups = this.get('groups');
-      groups.on('mouseover', null);
-      groups.on('mouseout', null);
+      let viewportBars = this.getViewportBars();
+      viewportBars.on('mouseover', null);
+      viewportBars.on('mouseout', null);
     }
     Ember.run.cancel(this._scheduledRedraw);
     this._super(...arguments);

--- a/addon/components/pie-chart.js
+++ b/addon/components/pie-chart.js
@@ -49,9 +49,9 @@ const PieChartComponent = ChartComponent.extend(FloatingTooltipMixin,
 
   willDestroyElement: function() {
     if(this._hasMouseEventListeners) {
-      let groups = this.get('groups');
-      groups.on('mouseover', null);
-      groups.on('mouseout', null);
+      let viewportArc = this.getViewportArc();
+      viewportArc.on('mouseover', null);
+      viewportArc.on('mouseout', null);
     }
     this._super(...arguments);
   },
@@ -564,9 +564,13 @@ const PieChartComponent = ChartComponent.extend(FloatingTooltipMixin,
   // Selections
   // ----------------------------------------------------------------------------
 
+  getViewportArc() {
+    return this.get('viewport').selectAll('.arc');
+  },
+
   groups: Ember.computed(function() {
     var data = this.get('pie')(this.get('finishedData'));
-    return this.get('viewport').selectAll('.arc').data(data);
+    return this.getViewportArc().data(data);
   }).volatile(),
 
   // ----------------------------------------------------------------------------

--- a/addon/components/scatter-chart.js
+++ b/addon/components/scatter-chart.js
@@ -63,9 +63,9 @@ const ScatterChartComponent = ChartComponent.extend(LegendMixin, FloatingTooltip
 
   willDestroyElement: function() {
     if(this._hasMouseEventListeners) {
-      let groups = this.get('groups');
-      groups.on('mouseover', null);
-      groups.on('mouseout', null);
+      let viewportGroups = this.getViewportGroups();
+      viewportGroups.on('mouseover', null);
+      viewportGroups.on('mouseout', null);
 
       let viewport = this.get('viewport');
       let totalGroup = viewport.select('.totalgroup');
@@ -383,9 +383,13 @@ const ScatterChartComponent = ChartComponent.extend(LegendMixin, FloatingTooltip
   // ----------------------------------------------------------------------------
   // Selections
   // ----------------------------------------------------------------------------
+    //
+  getViewportGroups() {
+    return this.get('viewport').selectAll('.group');
+  },
 
   groups: Ember.computed(function() {
-    return this.get('viewport').selectAll('.group').data(this.get('finishedData'));
+    return this.getViewportGroups().data(this.get('finishedData'));
   }).volatile(),
 
   selectOrCreateAxis: function(selector) {

--- a/addon/components/stacked-vertical-bar-chart.js
+++ b/addon/components/stacked-vertical-bar-chart.js
@@ -96,14 +96,13 @@ const StackedVerticalBarChartComponent = ChartComponent.extend(LegendMixin,
    */
   maxLabelHeight: 50,
 
-
   willDestroyElement: function() {
     if(this._hasMouseEventListeners) {
-      let bars = this.get('bars');
-      bars.on('mouseover', null);
-      bars.on('mouseout', null);
+      let viewportBars = this.getViewportBars();
+      viewportBars.on('mouseover', null);
+      viewportBars.on('mouseout', null);
 
-      let slices = bars.selectAll('rect');
+      let slices = viewportBars.selectAll('rect');
       slices.on('mouseover', null);
       slices.on('mouseout', null);
     }
@@ -871,10 +870,12 @@ const StackedVerticalBarChartComponent = ChartComponent.extend(LegendMixin,
   // Selections
   // ---------------------------------------------------------------------------
 
+  getViewportBars() {
+    return this.get('viewport').selectAll('.bars');
+  },
+
   bars: Ember.computed(function() {
-    return this.get('viewport')
-               .selectAll('.bars')
-               .data(this.get('finishedData'));
+    return this.getViewportBars().data(this.get('finishedData'));
   }).volatile(),
 
   yAxis: Ember.computed(function() {

--- a/addon/components/time-series-chart.js
+++ b/addon/components/time-series-chart.js
@@ -817,20 +817,24 @@ const TimeSeriesChartComponent = ChartComponent.extend(LegendMixin,
 
   removeAllGroups: function() {
     this._removeMouseEventListeners();
-    this.get('viewport').selectAll('.bars').remove();
+    this.getViewportBars().remove();
   },
 
   _removeMouseEventListeners: function() {
     if(this._hasMouseEventListeners) {
-      let groups = this.get('groups');
-      let bars = groups.selectAll('rect');
+      let viewportBars = this.getViewportBars();
+      let bars = viewportBars.selectAll('rect');
       bars.on('mouseover', null);
       bars.on('mouseout', null);
     }
   },
 
+  getViewportBars() {
+    return this.get('viewport').selectAll('.bars');
+  },
+
   groups: Ember.computed(function() {
-    return this.get('viewport').selectAll('.bars').data(this.get('_groupedBarData'));
+    return this.getViewportBars().data(this.get('_groupedBarData'));
   }).volatile(),
 
   removeAllSeries: function() {

--- a/addon/components/vertical-bar-chart.js
+++ b/addon/components/vertical-bar-chart.js
@@ -55,11 +55,11 @@ const VerticalBarChartComponent = ChartComponent.extend(LegendMixin,
 
   willDestroyElement: function() {
     if(this._hasMouseEventListeners) {
-      let groups = this.get('groups');
-      groups.on('mouseover', null);
-      groups.on('mouseout', null);
+      let viewportBars = this.getViewportBars();
+      viewportBars.on('mouseover', null);
+      viewportBars.on('mouseout', null);
 
-      let bars = groups.selectAll('rect');
+      let bars = viewportBars.selectAll('rect');
       bars.on('mouseover', null);
       bars.on('mouseout', null);
     }
@@ -641,8 +641,12 @@ const VerticalBarChartComponent = ChartComponent.extend(LegendMixin,
   // Selections
   // ----------------------------------------------------------------------------
 
+  getViewportBars() {
+    return this.get('viewport').selectAll('.bars');
+  },
+
   groups: Ember.computed(function() {
-    return this.get('viewport').selectAll('.bars').data(this.get('finishedData'));
+    return this.getViewportBars().data(this.get('finishedData'));
   }).volatile(),
 
   yAxis: Ember.computed(function() {


### PR DESCRIPTION
The teardown step was calling not only the d3 selector code, but also `data(` and its argument. This means at teardown we're forcing re-computation of the rendered data. This is expensive, and additionally may not always reliably work (since the UI is in the middle of teardown state is kind of wonky).

Calling `data(` is not required however, only the d3 selector need to be called.

I confirmed the memory leak fix isn't regressed with this change. For these charts I'm running the test suite and clicking the GC button around ten seconds. The number of nodes steadily increases, but you expect that to happen running QUnit. It doesn't appear skipping `data(` during teardown changes any behavior.

Before any of the memory leak work you can see listeners barely drop when GC is triggered:

<img width="838" alt="Screen Shot 2019-05-10 at 1 39 16 PM" src="https://user-images.githubusercontent.com/8752/57545665-184c0780-7329-11e9-978e-799839b90998.png">

Master you can see them drop sharply:

<img width="839" alt="Screen Shot 2019-05-10 at 1 32 29 PM" src="https://user-images.githubusercontent.com/8752/57545683-24d06000-7329-11e9-98f7-888b99689d3a.png">

This PR the same:

<img width="835" alt="Screen Shot 2019-05-10 at 1 33 33 PM" src="https://user-images.githubusercontent.com/8752/57545692-29951400-7329-11e9-9ff0-e0ebd2d15cf7.png">