### PR TITLE
Refactor computed properties to avoid deprecated combined getter setters

### DIFF
--- a/addon/components/time-series-chart.js
+++ b/addon/components/time-series-chart.js
@@ -414,19 +414,33 @@ const TimeSeriesChartComponent = ChartComponent.extend(LegendMixin,
   // For a dynamic x axis, let the max number of labels be the minimum of
   // the number of x ticks and the assigned value. This is to prevent
   // the assigned value from being so large that labels flood the x axis.
-  maxNumberOfLabels: Ember.computed('numXTicks', 'dynamicXAxis', 'maxNumberOfRotatedLabels', 'xAxisVertLabels', function(key, value){
-    var allowableTicks = this.get('numXTicks');
-    if (this.get('xAxisVertLabels')) {
-      allowableTicks = this.get('maxNumberOfRotatedLabels');
-    }
-
-    if (this.get('dynamicXAxis')) {
-      if (isNaN(value)) {
-        value = this.get('DEFAULT_MAX_NUMBER_OF_LABELS');
+  maxNumberOfLabels: Ember.computed('numXTicks', 'dynamicXAxis', 'maxNumberOfRotatedLabels', 'xAxisVertLabels', {
+    get() {
+      var allowableTicks = this.get('numXTicks');
+      if (this.get('xAxisVertLabels')) {
+        allowableTicks = this.get('maxNumberOfRotatedLabels');
       }
-      return Math.min(value, allowableTicks);
-    } else {
-      return allowableTicks;
+
+      if (this.get('dynamicXAxis')) {
+        return Math.min(this.get('DEFAULT_MAX_NUMBER_OF_LABELS'), allowableTicks);
+      } else {
+        return allowableTicks;
+      }
+    },
+    set(key, value) {
+      var allowableTicks = this.get('numXTicks');
+      if (this.get('xAxisVertLabels')) {
+        allowableTicks = this.get('maxNumberOfRotatedLabels');
+      }
+
+      if (this.get('dynamicXAxis')) {
+        if (isNaN(value)) {
+          value = this.get('DEFAULT_MAX_NUMBER_OF_LABELS');
+        }
+        return Math.min(value, allowableTicks);
+      } else {
+        return allowableTicks;
+      }
     }
   }),
 

--- a/addon/mixins/time-series-labeler.js
+++ b/addon/mixins/time-series-labeler.js
@@ -78,19 +78,36 @@ export default Ember.Mixin.create({
   // If the x axis is not dynamically labelled, then the domain type
   // is simply the selectedInterval
   MONTHS_IN_QUARTER: 3,
-  xAxisTimeInterval: Ember.computed('selectedInterval', 'dynamicXAxis', function(key, value) {
-    var domain;
-    if (this.get('dynamicXAxis')) {
-      domain = value || 'M';
-    } else {
-      domain = this.get('selectedInterval');
-    }
-    // to maintain consistency, convert the domain type into its
-    // single letter representation
-    if (domain.length > 1) {
-      return longDomainTypeToDomainType[domain];
-    } else {
-      return domain;
+  xAxisTimeInterval: Ember.computed('selectedInterval', 'dynamicXAxis', {
+    get() {
+      var domain;
+      if (this.get('dynamicXAxis')) {
+        domain = 'M';
+      } else {
+        domain = this.get('selectedInterval');
+      }
+      // to maintain consistency, convert the domain type into its
+      // single letter representation
+      if (domain.length > 1) {
+        return longDomainTypeToDomainType[domain];
+      } else {
+        return domain;
+      }
+    },
+    set(key, value) {
+      var domain;
+      if (this.get('dynamicXAxis')) {
+        domain = value || 'M';
+      } else {
+        domain = this.get('selectedInterval');
+      }
+      // to maintain consistency, convert the domain type into its
+      // single letter representation
+      if (domain.length > 1) {
+        return longDomainTypeToDomainType[domain];
+      } else {
+        return domain;
+      }
     }
   }),
 


### PR DESCRIPTION
This PR refactor computed properties to avoid deprecated combined getter setters into the modern split getter/setter styles.

I could have tried to dedupe the getter and setters paths a bit better but I didn't want to risk messing up the logic as I'm not familiar with this code.

Ultimately, I think the real solution is to refactor away from having this kind of logic in setters entirely so I went with the straightforward refactor.