### PR TITLE
Use ember-object-set-return-value codemod to cleanup set return value usage

### DIFF
--- a/addon/components/stacked-vertical-bar-chart.js
+++ b/addon/components/stacked-vertical-bar-chart.js
@@ -912,7 +912,7 @@ const StackedVerticalBarChartComponent = ChartComponent.extend(LegendMixin,
         }
       });
     }
-    return this.set('_shouldRotateLabels', rotateLabels);
+    this.set('_shouldRotateLabels', rotateLabels);
   },
 
   // Calculate the number of degrees to rotate labels based on how widely labels

--- a/addon/components/vertical-bar-chart.js
+++ b/addon/components/vertical-bar-chart.js
@@ -690,7 +690,7 @@ const VerticalBarChartComponent = ChartComponent.extend(LegendMixin,
         }
       });
     }
-    return this.set('_shouldRotateLabels', rotateLabels);
+    this.set('_shouldRotateLabels', rotateLabels);
   },
 
   // Calculate the number of degrees to rotate labels based on how widely labels

--- a/tests/dummy/app/components/scrubber-component.js
+++ b/tests/dummy/app/components/scrubber-component.js
@@ -10,7 +10,7 @@ export default Ember.Component.extend({
   step: 1,
   change: function() {
     var value = this.$()[0].value;
-    return this.set('value', +value);
+    this.set('value', +value);
   }
 
 });

--- a/tests/unit/horizontal-bar-test.js
+++ b/tests/unit/horizontal-bar-test.js
@@ -138,7 +138,7 @@ test("Labels aren't trimmed when width is small", function(assert) {
   this.render();
   // Charts set their defaultOuterWidth when they're rendered, so it has to be
   // set after rendering
-  Ember.run(() => component.set('defaultOuterWidth', 300));
+  Ember.run(() => { component.set('defaultOuterWidth', 300); });
 
   const groupLabels = component.$('text.group');
   const noLabelsTruncated = every(groupLabels, function(label) {


### PR DESCRIPTION
I used an internal codemod [ember-object-set-return-value](https://github.com/Addepar/iverson-codemods/blob/master/transforms/ember-object-set-return-value/README.md) to identify usages of `set`'s return value and then cleaned these cases up manually.

I don't think any of these actually are necessary to remove for upgrading to Ember 2, but it does provide peace of mind.