### PR TITLE
[ADPR-62603] Abort drawChart if layout sets

### DIFF
--- a/addon/components/chart-component.js
+++ b/addon/components/chart-component.js
@@ -271,6 +271,10 @@ const ChartComponent = Ember.Component.extend(ColorableMixin, ResizeHandlerMixin
     this.$('.chart-viewport').children().remove();
   },
 
+  getHasScheduledDraw() {
+    return this._scheduledDrawCount > 0;
+  },
+
   // Remove previous drawing
   draw: function() {
     this._scheduledDrawCount--;

--- a/tests/unit/vertical-bar-test.js
+++ b/tests/unit/vertical-bar-test.js
@@ -266,3 +266,45 @@ test('Pull Request #182: A bar-specific color override is respected', function(a
     "There is a bar in the chart with the correct override color " + barOverrideColor
   );
 });
+
+test('ADPR-62603: An infinite loop based on label orientation will not occur', function(assert) {
+  let testData = [
+    {"label":"Preservation","value":0.0365451846828686},
+    {"label":"Growth","value":-0.05189082702329095},
+    {"label":"Inflation","value":0.4651320110022441}
+  ];
+
+  let container = document.querySelector('#ember-testing');
+  let oldStyle = container.getAttribute('style');
+  try {
+    container.style.width='482.39px';
+    container.style.height='176px';
+    container.style.transform='scale(1.0)';
+
+    let component = this.subject({
+      data: testData,
+      labelAngle: -1,
+      labelWidthMultiplier: 0.25,
+      portfolioVisualizationLabelHeight: 50,
+      showChartControls: true,
+      isInteractive: false,
+      isEditable: false,
+      maxBarThickness: null,
+      minBarThickness: null,
+      defaultOuterHeight: 176,
+      defaultOuterWidth: 482,
+      labelWidthOffset: 55.39,
+      axisTitleHeight: 10,
+      barWidth: 63,
+      sortKey: null,
+      maxAxisValue: 0.8,
+      minAxisValue: -0.2,
+      formatValueAxis: value => `%${Math.round(value*100)}`
+    });
+    this.render();
+
+    assert.ok(true, 'test completed');
+  } finally {
+    container.setAttribute('style', oldStyle);
+  }
+});


### PR DESCRIPTION
See comment in the code. If `updateLayout` sets an observed `renderVar` (and schedule a subsequent redraw), then abort the current render steps as we should permit that change to propagate to the DOM before proceeding with later steps which measure the DOM.

In use, the scheduled rerender was causing an infinite loop where a label rotation change scheduled an update, but `updateAxes` read the DOM before that change was realized, then the rotation change was drawn which caused the axes to read differently and set a padding value which again caused the rotation to change.

This test never recreated the infinite loop, though it is visually similar to the offending chart.

<details>
<summary>offending chart</summary>
<img width="254" alt="Screen Shot 2020-05-27 at 1 01 51 PM" src="https://user-images.githubusercontent.com/8752/83052204-fb11d600-a01c-11ea-9c05-56f4426e684b.png">
</details>

<details>
<summary>chart in added test</summary>
<img width="255" alt="Screen Shot 2020-05-27 at 1 02 35 PM" src="https://user-images.githubusercontent.com/8752/83052205-fb11d600-a01c-11ea-8432-0315b29a62fa.png">
</details>